### PR TITLE
Fix: Google Cloud label fix 

### DIFF
--- a/charts/iam-partial-policy/Chart.yaml
+++ b/charts/iam-partial-policy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: iam-partial-policy
 description: A Helm chart for creating Google Cloud IAM Partial Policy.
 type: application
-version: 0.1.4
+version: 0.1.5
 

--- a/charts/iam-partial-policy/templates/_helpers.tpl
+++ b/charts/iam-partial-policy/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "iam-partial-policy.labels" -}}
 app: {{ .Release.Name }}
 chart-name: {{ .Chart.Name }}
-chart-version: {{ .Chart.Version }}
+chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0}}
 {{- end -}}

--- a/charts/iam-partial-policy/values.yaml
+++ b/charts/iam-partial-policy/values.yaml
@@ -6,6 +6,7 @@
 
 global:
   # Add labels from a parent chart to all manifests.
+  # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
 bindings:
@@ -13,6 +14,7 @@ bindings:
 - name: iampartialpolicy-sample-project
 
   # Labels on the Config Connector resource.
+  # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
   # Annotations on the Config Connector resource.

--- a/charts/iam-service-account-key/Chart.yaml
+++ b/charts/iam-service-account-key/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: iam-service-account-key
 description: A Helm chart for creating Google Cloud IAM service account keys.
 type: application
-version: 0.2.4
+version: 0.2.5
 

--- a/charts/iam-service-account-key/templates/_helpers.tpl
+++ b/charts/iam-service-account-key/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "iam-service-account-key.labels" -}}
 app: {{ .Release.Name }}
 chart-name: {{ .Chart.Name }}
-chart-version: {{ .Chart.Version }}
+chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0 }}
 {{- end -}}

--- a/charts/iam-service-account-key/values.yaml
+++ b/charts/iam-service-account-key/values.yaml
@@ -6,12 +6,14 @@
 
 global:
   # Add labels from a parent chart to all manifests.
+  # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
 # Name of the Config Connector resource.
 name: iamserviceaccountkey-sample
 
 # Labels on the Config Connector resource.
+# Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
 labels: {}
 
 # Annotations on the Config Connector resource.

--- a/charts/iam-service-account/Chart.yaml
+++ b/charts/iam-service-account/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: iam-service-account
 description: A Helm chart for creating Google Cloud IAM service accounts.
 type: application
-version: 1.1.3
+version: 1.1.4

--- a/charts/iam-service-account/templates/_helpers.tpl
+++ b/charts/iam-service-account/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "iam-service-account.labels" -}}
 app: {{ .Release.Name }}
 chart-name: {{ .Chart.Name }}
-chart-version: {{ .Chart.Version }}
+chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0 }}
 {{- end -}}

--- a/charts/iam-service-account/values.yaml
+++ b/charts/iam-service-account/values.yaml
@@ -6,6 +6,7 @@
 
 global:
   # Add labels from a parent chart to all manifests.
+  # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
 # Name of the Config Connector resource.
@@ -13,6 +14,7 @@ global:
 name: iamserviceaccount-sample
 
 # Labels on the Config Connector resource.
+# Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
 labels: {}
 
 # Annotations on the Config Connector resource.

--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 2.1.3
+version: 2.1.4

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "sqlinstance.labels" -}}
 app: {{ .Release.Name }}
 chart-name: {{ .Chart.Name }}
-chart-version: {{ .Chart.Version }}
+chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0 }}
 {{- end -}}

--- a/charts/sqlinstance/values.yaml
+++ b/charts/sqlinstance/values.yaml
@@ -6,6 +6,7 @@
 
 global:
   # Add labels from a parent chart to all manifests.
+  # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
 ######################################################
@@ -22,6 +23,7 @@ name: sqlinstance-sample
 argoSyncWave: -5
 
 # Labels on the Config Connector resource.
+# Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
 labels: {}
 
 # Annotations on the Config Connector resource.

--- a/charts/storagebucket/Chart.yaml
+++ b/charts/storagebucket/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: storagebucket
 description: A Helm chart for creating Google Cloud Storage Bucket.
 type: application
-version: 0.2.2
+version: 0.2.3

--- a/charts/storagebucket/templates/_helpers.tpl
+++ b/charts/storagebucket/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "storagebucket.labels" -}}
 app: {{ .Release.Name }}
 chart-name: {{ .Chart.Name }}
-chart-version: {{ .Chart.Version }}
+chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0 }}
 {{- end -}}

--- a/charts/storagebucket/values.yaml
+++ b/charts/storagebucket/values.yaml
@@ -6,12 +6,14 @@
 
 global:
   # Add labels from a parent chart to all manifests.
+  # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
 # StorageBucket names must be globally unique.
 name: unique-storage-name
 
 # Labels on the Config Connector resource.
+# Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
 labels: {}
 
 # Annotations on the Config Connector resource.


### PR DESCRIPTION
Google Cloud does not allow dots (.) in the label name. 
This pull request replaces dots with hyphens in the `chart-version` label.