### PR TITLE
feat: changed topics and subscriptions array to map

### DIFF
--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 0.0.3
+version: 1.0.0
 

--- a/charts/pub-sub/templates/pubsub-iam-partial-policy.yml
+++ b/charts/pub-sub/templates/pubsub-iam-partial-policy.yml
@@ -73,7 +73,7 @@ spec:
   bindings:
     - role: roles/pubsub.subscriber
       members:
-        {{- $subscribers := concat  ($sub.subscribers | default list) $.Values.globalSubscribers  }}
+        {{- $subscribers := concat  ($sub.subscribers | default list) $.Values.globalSubscribers | uniq }}
         {{- range $sa := $subscribers }}
         - member:  "serviceAccount:{{ $sa }}"
         {{- end }}

--- a/charts/pub-sub/values.yaml
+++ b/charts/pub-sub/values.yaml
@@ -32,10 +32,14 @@ labels: {}
 globalPublishers: []
   # - <service-account-name>@<my-project-id>.iam.gserviceaccount.com
 
-topics: []
-  # - name: my-topic-name-01
+topics: {}
+  # # The "topicShortName01" is not used for anything other than for you to reference in an environment values file.
+  # # Each short name must be unique.
+  # topicShortName01:
+  #   name: my-topic-name-01
 
   #   # Set below property to true to create the necessary policy bindings for a deadletter topic.
+  #   # (The default pubsub service account will get publisher role)
   #   isDeadletterTopic: false
 
   #   # When enabled, retains messages on the Topic for up to 31 days after they get acknowledged. This feature is not free.
@@ -44,13 +48,15 @@ topics: []
 
   #   # A list of full service accounts ID's to get the publisher role on this topic.
   #   publishers:
-  #     - <service-account-name>@<my-project-id>.iam.gserviceaccount.com
+  #     - <some-other-service-account-name>@<my-project-id>.iam.gserviceaccount.com
 
   # # Below example is a minumum configuration of a topic. No deadletter topic or no messageRetentionDuration.
-  # - name: my-topic-name-02
+  # topicShortName02:
+  #   name: my-topic-name-02
 
   # # Below is an example of a deadletter topic.
-  # - name: deadletter.my-topic-name
+  # topicShortName03:
+  #   name: deadletter.my-topic-name
   #   isDeadletterTopic: true
 
 ############################################################
@@ -68,12 +74,15 @@ globalSubscriptionSpecs: {}
   #   maximumBackoff: 600s
   #   minimumBackoff: 500s
 
-subscriptions: []
-  # - name: my-sub-name-01
+subscriptions: {}
+  # # The "subscriptionShortName01" is not used for anything other than for you to reference in an environment values file.
+  # # Each short name must be unique.
+  # subscriptionShortName01:
+  #   name: my-sub-name-01
 
   #   # A list of full service accounts ID's to get the subscriber role on this subscription.
-  #   subscribers: []
-  #     # - <service-account-name>@<my-project-id>.iam.gserviceaccount.com
+  #   subscribers:
+  #     - <some-other-service-account-name>@<my-project-id>.iam.gserviceaccount.com
 
   #   # Below spec block supports all values from the documentation.
   #   # https://cloud.google.com/config-connector/docs/reference/resource-docs/pubsub/pubsubsubscription#spec
@@ -88,7 +97,8 @@ subscriptions: []
   #       minimumBackoff: 100s
 
   # # Below example is a minumum configuration of a subscription.
-  # - name: my-sub-name-02
+  # subscriptionShortName02:
+  #   name: my-sub-name-02
   #   spec:
   #     topicRef:
   #       name: my-topic-name-02


### PR DESCRIPTION
The `topics` and `subscriptions` arrays in the `values.yaml` and now maps instead.

### Before
**values.yaml**
```
topics:
  - name: my-topic-name-01
    retryPolicy:
      maximumBackoff: 600s
      minimumBackoff: 500s
    publishers:
      - some-service-account
```

### Now
**values.yaml**
```
topics:
  topicShortName01:
    name: my-topic-name-01
    retryPolicy:
      maximumBackoff: 600s
      minimumBackoff: 500s
    publishers:
      - some-service-account
```

Which means that you can now change vaules in the topics without rewriting the whole array in an another `values.yaml` file.

**values-test.yaml**
```
topics:
  topicShortName01:
    retryPolicy:
      maximumBackoff: 300s
    publishers:
      - some-other-service-account
```

