### PR TITLE
feat: added support for schemaSettings on topic

### DIFF
--- a/charts/pub-sub/templates/pubsub-topic.yaml
+++ b/charts/pub-sub/templates/pubsub-topic.yaml
@@ -26,9 +26,17 @@ metadata:
     {{- with $.Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- if $topic.messageRetentionDuration }}
+{{- with $topic }}
 spec:
-  messageRetentionDuration: {{ $topic.messageRetentionDuration | quote }}
+  {{- if .messageRetentionDuration }}
+  messageRetentionDuration: {{ .messageRetentionDuration | quote }}
+  {{- end }}
+  {{- if .schemaNameRef }}
+  schemaSettings:
+    encoding: {{ .encoding | default "JSON" }}
+    schemaRef:
+      name: {{ .schemaNameRef }}
+  {{- end }}
 {{- end }}
 ---
 {{- end }}

--- a/charts/pub-sub/values.yaml
+++ b/charts/pub-sub/values.yaml
@@ -63,6 +63,12 @@ topics: {}
   #   name: deadletter.my-topic-name
   #   isDeadletterTopic: true
 
+  # # Below is an example of a topic using a schema.
+  # # Create a schema and reference the name of it.
+  # topicShortName04:
+  #   name: my-topic-name-04
+  #   schemaNameRef: my-schema-name
+
 ############################################################
 #                      Subscriptions                       #
 ############################################################


### PR DESCRIPTION
Added support for referencing a PubSub Schema by name on a topic.
Support is only added for kind `PubSubSchema` in same namespace.

```yaml
topics:
  # Below is an example of a topic using a schema.
  # Create a schema and reference the name of it.
  topicShortName:
    name: my-topic-name
    schemaNameRef: my-schema-name
```