### PR TITLE
fix: removed empty spec: from topic

### DIFF
--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 1.1.0
-
+version: 1.1.1

--- a/charts/pub-sub/templates/pubsub-topic.yaml
+++ b/charts/pub-sub/templates/pubsub-topic.yaml
@@ -27,6 +27,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- with $topic }}
+{{- if or .messageRetentionDuration .schemaRef }}
 spec:
   {{- if .messageRetentionDuration }}
   messageRetentionDuration: {{ .messageRetentionDuration | quote }}
@@ -37,6 +38,7 @@ spec:
     schemaRef:
       name: {{ .schemaNameRef }}
   {{- end }}
+{{- end }}
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
If no `messageRetentionDuration` or `schemaRef` was defined, the `spec:` property would come up empty.
This would confuse Config Connector and you would need to replace the topic for et to work again.

This PR removes the empty spec.
```yaml
apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
kind: PubSubTopic
metadata:
  name: some-name
  labels:
    chart-name: pub-sub
    chart-version: 1-1-0
spec: # <---------
```