### PR TITLE
fix: permissions on big query dataset is now optional

### DIFF
--- a/charts/big-query/Chart.yaml
+++ b/charts/big-query/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: big-query
 description: A Helm chart for creating Google Cloud Big Query resources.
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/charts/big-query/templates/bq-dataset.yaml
+++ b/charts/big-query/templates/bq-dataset.yaml
@@ -14,14 +14,20 @@ spec:
   description: {{ .description }}
   location: europe-west3
   resourceID: {{ .name | lower | snakecase }}
+  {{- if .permissions }}
   access:
-    {{- range $user := .permissions.writer }}
+    {{- with .permissions.writer }}
+    {{- range . }}
     - role: WRITER
-      userByEmail: {{ $user }}
+      userByEmail: {{ . }}
     {{- end }}
-    {{- range $user := .permissions.reader }}
+    {{- end }}
+    {{- with .permissions.reader }}
+    {{- range . }}
     - role: READER
-      userByEmail: {{ $user }}
+      userByEmail: {{ . }}
     {{- end }}
+    {{- end }}
+  {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
This PR fixes the issue where both a writer and a reader is required for the chart to template.
This is no optional, one or the other... Or none..