### PR TITLE
refactor: BigQuery

### DIFF
--- a/charts/big-query/Chart.yaml
+++ b/charts/big-query/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: big-query
 description: A Helm chart for creating Google Cloud Big Query resources.
 type: application
-version: 0.1.1
+version: 1.0.0

--- a/charts/big-query/templates/_helpers.tpl
+++ b/charts/big-query/templates/_helpers.tpl
@@ -20,3 +20,39 @@ chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- end -}}
 {{ .name | required "A resource name is required." }}
 {{- end -}}
+
+{{- define "big-query.external-writer" -}}
+{{- range . }}
+{{- if regexMatch "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.iam\\.gserviceaccount\\.com$" . }}
+- role: WRITER
+  userByEmail: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "big-query.external-reader" -}}
+{{- range . }}
+{{- if regexMatch "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.iam\\.gserviceaccount\\.com$" . }}
+- role: READER
+  userByEmail: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "big-query.writer" -}}
+{{- range .users }}
+{{- if regexMatch "^[A-Za-z0-9._%+-]+$" . }}
+- role: WRITER
+  userByEmail: {{ printf "%s@%s.iam.gserviceaccount.com" . $.projectID }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "big-query.reader" -}}
+{{- range .users }}
+{{- if regexMatch "^[A-Za-z0-9._%+-]+$" . }}
+- role: READER
+  userByEmail: {{ printf "%s@%s.iam.gserviceaccount.com" . $.projectID }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/big-query/templates/bq-dataset.yaml
+++ b/charts/big-query/templates/bq-dataset.yaml
@@ -1,10 +1,12 @@
+{{ $configConnectorID := .Values.configConnectorSaId | required "A Config Connector SA ID is required" }}
+{{ $projectID := $.Values.global.projectID | required "Google ID is required" }}
 {{ range .Values.dataSets }}
 apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
 kind: BigQueryDataset
 metadata:
   name: {{ include "big-query.dataset-name" . }}
   annotations:
-    cnrm.cloud.google.com/delete-contents-on-destroy: {{ .deleteOnDestroy | default "false" | quote }}
+    cnrm.cloud.google.com/deletion-policy: abandon
   labels:
     {{- include "big-query.labels" $ | nindent 4 }}
     {{- with .labels }}
@@ -13,21 +15,21 @@ metadata:
 spec:
   description: {{ .description }}
   location: europe-west3
-  resourceID: {{ .name | lower | snakecase }}
-  {{- if .permissions }}
+  resourceID: {{ .name | lower | camelcase }}
   access:
-    {{- with .permissions.writer }}
-    {{- range . }}
-    - role: WRITER
-      userByEmail: {{ . }}
+    - role: OWNER
+      userByEmail: {{ $configConnectorID }}
+    {{- with ((.permissions).externalWriter) }}
+    {{ include "big-query.external-writer" . | indent 4}}
     {{- end }}
+    {{- with ((.permissions).externalReader) }}
+    {{ include "big-query.external-reader" . | indent 4}}
     {{- end }}
-    {{- with .permissions.reader }}
-    {{- range . }}
-    - role: READER
-      userByEmail: {{ . }}
+    {{- with ((.permissions).writer) }}
+    {{ include "big-query.writer" (dict "users" . "projectID" $projectID) | indent 4}}
     {{- end }}
+    {{- with ((.permissions).reader) }}
+    {{ include "big-query.reader" (dict "users" . "projectID" $projectID) | indent 4}}
     {{- end }}
-  {{- end }}
 ---
 {{- end }}

--- a/charts/big-query/templates/bq-table.yaml
+++ b/charts/big-query/templates/bq-table.yaml
@@ -5,6 +5,7 @@ kind: BigQueryTable
 metadata:
   name: {{ include "big-query.table-name" . }}
   labels:
+    dataset: {{ include "big-query.dataset-name" $dataset }}
     {{- include "big-query.labels" $ | nindent 4 }}
     {{- with .labels }}
       {{- toYaml . | nindent 4 }}

--- a/charts/big-query/templates/bq-table.yaml
+++ b/charts/big-query/templates/bq-table.yaml
@@ -4,6 +4,8 @@ apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
 kind: BigQueryTable
 metadata:
   name: {{ include "big-query.table-name" . }}
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: abandon
   labels:
     dataset: {{ include "big-query.dataset-name" $dataset }}
     {{- include "big-query.labels" $ | nindent 4 }}

--- a/charts/big-query/tests/dataset_test.yaml
+++ b/charts/big-query/tests/dataset_test.yaml
@@ -1,10 +1,12 @@
-# https://github.com/vbehar/helm3-unittest
+# https://github.com/helm-unittest/helm-unittest 
 suite: Big Query Dataset
 templates:
   - bq-dataset.yaml
 tests:
-  - it: Should pass with nothing but name set
+  - it: Should pass with nothing but name set and required props
     set:
+      global.projectID: some-project-id
+      configConnectorSaId: some-service-account-name
       dataSets.dataSetShortName01.name: some-dataset-name
     asserts:
       - equal:
@@ -12,10 +14,16 @@ tests:
           value: some-dataset-name
       - equal:
           path: spec.resourceID
-          value: some_dataset_name
+          value: SomeDatasetName
+      - equal:
+          path: metadata.annotations
+          value:
+            cnrm.cloud.google.com/deletion-policy: abandon
 
-  - it: Should set the resourceID to snakecase
+  - it: Should set the resourceID to PascalCase
     set:
+      global.projectID: some-project-id
+      configConnectorSaId: some-service-account-name
       dataSets.dataSetShortName01.name: some-dataset-name
     asserts:
       - equal:
@@ -23,27 +31,94 @@ tests:
           value: some-dataset-name
       - equal:
           path: spec.resourceID
-          value: some_dataset_name
+          value: SomeDatasetName
 
-  - it: Should set READER and WRITER permissions
+  - it: Should set the Config Connector SA to owner on Dataset
     set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+    asserts:
+      - equal:
+          path: spec.access[0].role
+          value: OWNER
+      - equal:
+          path: spec.access[0].userByEmail
+          value: cc-service-account@some-project-id.iam.gserviceaccount.com
+
+  - it: Should set READER and WRITER permissions on service account name
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: some-service-account-name
       dataSets.dataSetShortName01:
         name: some-dataset-name
         permissions:
           writer:
-            - writer@email.org
+            - some-sa-name
           reader:
-            - reader@email.org
+            - some-sa-name
     asserts:
       - equal:
-          path: spec.access[0].role
+          path: spec.access[1].role
           value: WRITER
       - equal:
-          path: spec.access[0].userByEmail
-          value: writer@email.org
+          path: spec.access[1].userByEmail
+          value: some-sa-name@some-project-id.iam.gserviceaccount.com
       - equal:
-          path: spec.access[1].role
+          path: spec.access[2].role
           value: READER
       - equal:
+          path: spec.access[2].userByEmail
+          value: some-sa-name@some-project-id.iam.gserviceaccount.com
+
+  - it: Should set READER and WRITER permissions on external service account name
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: some-service-account-name
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+        permissions:
+          externalWriter:
+            - some-sa-name@some-project-id.iam.gserviceaccount.com
+          externalReader:
+            - some-sa-name@some-project-id.iam.gserviceaccount.com
+    asserts:
+      - equal:
+          path: spec.access[1].role
+          value: WRITER
+      - equal:
           path: spec.access[1].userByEmail
-          value: reader@email.org
+          value: some-sa-name@some-project-id.iam.gserviceaccount.com
+      - equal:
+          path: spec.access[2].role
+          value: READER
+      - equal:
+          path: spec.access[2].userByEmail
+          value: some-sa-name@some-project-id.iam.gserviceaccount.com
+
+  - it: Should NOT give any of the given users access, sinces they do not meet the regexMatch
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: some-service-account-name
+      dataSets.dataSetShortName01:
+          name: some-dataset-name
+          permissions:
+            externalWriter:
+              - some-sa-name@some-different-domain.com
+              - some-name
+            externalReader:
+              - some-sa-name@some-different-domain.com
+              - some-name
+            writer:
+              - some-name@other-domain.com
+              - some-name@some-project-id.iam.gserviceaccount.com 
+            reader:
+              - some-name@other-domain.com
+              - some-name@some-project-id.iam.gserviceaccount.com 
+    asserts:
+      - contains:
+          path: spec.access
+          content:
+            role: OWNER
+            userByEmail: some-service-account-name@some-project-id.iam.gserviceaccount.com

--- a/charts/big-query/tests/table_test.yaml
+++ b/charts/big-query/tests/table_test.yaml
@@ -5,6 +5,8 @@ templates:
 tests:
   - it: Should set the resourceID to pascalcase
     set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
       dataSets.dataSetShortName01:
         name: some-dataset-name
         tables:
@@ -16,6 +18,8 @@ tests:
 
   - it: Should set the database reference to dataset name
     set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
       dataSets.dataSetShortName01:
         name: some-dataset-name
         tables:
@@ -27,6 +31,8 @@ tests:
 
   - it: Should only template view if view is defined
     set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
       dataSets.dataSetShortName01:
         name: some-dataset-name
         tables:
@@ -44,13 +50,15 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.view
-      - isEmpty:
+      - isNull:
           path: spec.schema
-      - isEmpty:
+      - isNull:
           path: spec.timePartitioning
 
   - it: Should not be able to set timePartitioning if view is defined
     set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
       dataSets.dataSetShortName01:
         name: some-dataset-name
         tables:
@@ -64,8 +72,8 @@ tests:
     asserts:
       - isNotEmpty:
           path: spec.view
-      - isEmpty:
+      - isNull:
           path: spec.schema
-      - isEmpty:
+      - isNull:
           path: spec.timePartitioning
 

--- a/charts/big-query/values.yaml
+++ b/charts/big-query/values.yaml
@@ -9,6 +9,16 @@ global:
   # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
+  # The Google Project ID.
+  # [Required]
+  projectID: null
+
+# The full ID of the Config Connector service account which will create the BigQuery resources.
+# This is due to a limitation on the CC BigQuery provider.
+# See https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/127 for more details.
+# [Required]
+configConnectorSaId: null
+
 dataSets: {}
   # # The "dataSetShortName01" is not used for anything other than for you to reference the object in an environment values file.
   # # Each short name must be unique.
@@ -18,10 +28,19 @@ dataSets: {}
   #   name: my-dataset-name
   #   description: "BigQuery Dataset Sample"
   #   permissions:
+  #     # Below fields are used for SA's  that do not belong to the "global.projectID".
+  #     # They must end with ".iam.gserviceaccount.com" or they will not be added.
+  #     externalWriter:
+  #       - <service-account-name>@<project-id>.iam.gserviceaccount.com
+  #     externalReader:
+  #       - <service-account-name>@<project-id>.iam.gserviceaccount.com
+  #
+  #     # Below fields only takes the names of the SA. The "global.projectID" will be used to create the rest of the ID.
   #     writer:
-  #       - <service-account-name>@<project-id>.iam.gserviceaccount.com
+  #       - <service-account-name>
   #     reader:
-  #       - <service-account-name>@<project-id>.iam.gserviceaccount.com
+  #       - <service-account-name>
+  #
   #   tables:
   #     # The table name can only include lowercase alphanumeric characters and hyphens (-).
   #     # The table name will be converted to pascalcase in BigQuery, eg. my-table-name will be MyTableName.


### PR DESCRIPTION
A big refactor of how the Chart works.

- A project ID is now required under the global property
- The Google ID of the Config Connector service account is required for adding the SA as `OWNER`, see https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/127
- There are now `writer/reader` and `externalWriter/externalReader` permissions on the Datesat.
  - `writer/reader` takes a SA name and will generate the full ID from the `projectID` field.
  - `externalWriter/externalReader` takes a full ID. Enables you to add SA's from other projects.
- Tables are labeled with the name of the Dataset they belong.
- Datasets and Tabels have the `cnrm.cloud.google.com/deletion-policy: abandon` annotation.
- Updated Unit tests accordingly.