### PR TITLE
feature: added support for workload identity

### DIFF
--- a/charts/iam-service-account/Chart.yaml
+++ b/charts/iam-service-account/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: iam-service-account
 description: A Helm chart for creating Google Cloud IAM service accounts.
 type: application
-version: 2.0.0-rc1
+version: 2.0.0-rc2

--- a/charts/iam-service-account/Chart.yaml
+++ b/charts/iam-service-account/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: iam-service-account
 description: A Helm chart for creating Google Cloud IAM service accounts.
 type: application
-version: 2.0.0-rc2
+version: 2.0.0

--- a/charts/iam-service-account/Chart.yaml
+++ b/charts/iam-service-account/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: iam-service-account
 description: A Helm chart for creating Google Cloud IAM service accounts.
 type: application
-version: 1.1.4
+version: 2.0.0-rc1

--- a/charts/iam-service-account/templates/_helpers.tpl
+++ b/charts/iam-service-account/templates/_helpers.tpl
@@ -5,4 +5,7 @@ chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0 }}
 {{- end -}}
+{{- with .Values.labels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
 {{- end -}}

--- a/charts/iam-service-account/templates/iam-policy-member.yaml
+++ b/charts/iam-service-account/templates/iam-policy-member.yaml
@@ -13,6 +13,6 @@ spec:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
     name: {{ .Values.name }}
-  member: "serviceAccount:{{ $gkeProjectID }}.svc.id.goog[{{ .Release.Namespace }}/{{ .Values.name }}]"
+  member: "serviceAccount:{{ $gkeProjectID }}.svc.id.goog[{{ .Values.workloadIdentity.kubernetesNamespace }}/{{ .Values.name }}]"
   role: roles/iam.workloadIdentityUser
 {{- end }}

--- a/charts/iam-service-account/templates/iam-policy-member.yaml
+++ b/charts/iam-service-account/templates/iam-policy-member.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.workloadIdentity.enabled }}
+{{- $gkeProjectID := .Values.workloadIdentity.gkeProjectID | required "A gkeProjectID is required for workloadIdentity" }}
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: {{ .Values.name }}-wl-identity
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
+  labels:
+    {{- include "iam-service-account.labels" . | nindent 4 }}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: {{ .Values.name }}
+  member: "serviceAccount:{{ $gkeProjectID }}.svc.id.goog[{{ .Release.Namespace }}/{{ .Values.name }}]"
+  role: roles/iam.workloadIdentityUser
+{{- end }}

--- a/charts/iam-service-account/templates/iam-service-account-key.yaml
+++ b/charts/iam-service-account/templates/iam-service-account-key.yaml
@@ -4,16 +4,13 @@ kind: IAMServiceAccountKey
 metadata:
   name: {{ .Values.name }}-key
   annotations:
-    {{- with .Values.keyFile.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
     argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
+    {{- with .Values.keyFile.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     okcloud.dk/secret-type: gsa-key
     {{- include "iam-service-account.labels" . | nindent 4 }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
 spec:
   keyAlgorithm: {{ .Values.spec.keyAlgorithm | default "KEY_ALG_RSA_2048" }}
   privateKeyType: {{ .Values.spec.privateKeyType | default "TYPE_GOOGLE_CREDENTIALS_FILE" }}

--- a/charts/iam-service-account/templates/iam-service-account-key.yaml
+++ b/charts/iam-service-account/templates/iam-service-account-key.yaml
@@ -3,15 +3,11 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccountKey
 metadata:
   name: {{ .Values.name }}-key
-  {{- if or (.Values.keyFile.annotations) (.Values.argoSyncWave) }}
   annotations:
     {{- with .Values.keyFile.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.argoSyncWave }}
-    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | quote }}
-    {{- end }}
-  {{- end }}
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
   labels:
     okcloud.dk/secret-type: gsa-key
     {{- include "iam-service-account.labels" . | nindent 4 }}

--- a/charts/iam-service-account/templates/iam-service-account.yaml
+++ b/charts/iam-service-account/templates/iam-service-account.yaml
@@ -9,9 +9,6 @@ metadata:
     argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
   labels:
     {{- include "iam-service-account.labels" . | nindent 4 }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
 spec:
   displayName: {{ .Values.name | replace "-" " " | title }}
   description: {{ .Values.spec.description | quote}}

--- a/charts/iam-service-account/templates/iam-service-account.yaml
+++ b/charts/iam-service-account/templates/iam-service-account.yaml
@@ -2,21 +2,17 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
   name: {{ .Values.name | required "A resource name is required." }}
-  {{- if or (.Values.annotations) (.Values.argoSyncWave) }}
   annotations:
     {{- with .Values.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.argoSyncWave }}
-    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | quote }}
-    {{- end }}
-  {{- end }}
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
   labels:
     {{- include "iam-service-account.labels" . | nindent 4 }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .Values.spec }}
-    {{- toYaml . | nindent 2 }}
-  {{- end }}
+  displayName: {{ .Values.name | replace "-" " " | title }}
+  description: {{ .Values.spec.description | quote}}
+  disabled: {{ .Values.spec.disabled | default false }}

--- a/charts/iam-service-account/templates/kubernetes-service-acccount.yaml
+++ b/charts/iam-service-account/templates/kubernetes-service-acccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.workloadIdentity.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.name }}@{{ .Values.global.projectID | required "projectID is required"}}.iam.gserviceaccount.com
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
+  labels:
+    {{- include "iam-service-account.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/iam-service-account/values.yaml
+++ b/charts/iam-service-account/values.yaml
@@ -32,6 +32,10 @@ spec:
 # Access Management (IAM) service accounts to access Google Cloud services.
 workloadIdentity:
   enabled: false
+
+  # The Kubernetes Namespace your service account is in.
+  kubernetesNamespace: default
+
   # The ID of the Google Cloud Project that contains the Kubernetes cluster.
   gkeProjectID: some-project-id
 

--- a/charts/iam-service-account/values.yaml
+++ b/charts/iam-service-account/values.yaml
@@ -1,7 +1,3 @@
-# Default values for iam-service-account.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 # https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount
 
 global:
@@ -9,6 +5,10 @@ global:
   # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
+  # The Google Project ID.
+  # [Required for Workload Identity]
+  projectID: null 
+ 
 # Name of the Config Connector resource.
 # The name will be the ID of the Google Service Account and must be between 6 and 30 characters.
 name: iamserviceaccount-sample
@@ -28,6 +28,14 @@ spec:
   # A text description of the service account. Must be less than or equal to 256 UTF-8 bytes.
   description: "Description of Service Account"
 
+# Workload Identity allows workloads in your GKE clusters to impersonate Identity and
+# Access Management (IAM) service accounts to access Google Cloud services.
+workloadIdentity:
+  enabled: false
+  # The ID of the Google Cloud Project that contains the Kubernetes cluster.
+  gkeProjectID: some-project-id
+
+# [ DEPRECATED ] Use workload identity!
 # If keyFile is enabled, Config Connector will create a service account JSON key file and
 # add it to the K8s namespace as a secret called "<service-account-name>-key".
 # In this example the secret will be named "iamserviceaccount-sample-key".

--- a/charts/iam-service-account/values.yaml
+++ b/charts/iam-service-account/values.yaml
@@ -43,21 +43,3 @@ spec:
 # In this example the secret will be named "iamserviceaccount-sample-key".
 keyFile:
   create: false
-
-  # Labels on the Config Connector resource.
-  labels: {}
-
-  # Annotations on the Config Connector resource.
-  annotations: {}
-  spec:
-    # Immutable. The algorithm used to generate the key, used only on create.
-    # KEY_ALG_RSA_2048 is the default algorithm. Valid values are: "KEY_ALG_RSA_1024", "KEY_ALG_RSA_2048".
-    keyAlgorithm: KEY_ALG_RSA_2048
-
-    # Immutable.
-    publicKeyType: TYPE_X509_PEM_FILE
-
-    # Immutable. A field that allows clients to upload their own public key.
-    # If set, use this public key data to create a service account key for given service account.
-    # Please note, the expected format for this field is a base64 encoded X509_PEM.
-    privateKeyType: TYPE_GOOGLE_CREDENTIALS_FILE

--- a/charts/iam-service-account/values.yaml
+++ b/charts/iam-service-account/values.yaml
@@ -28,16 +28,6 @@ spec:
   # A text description of the service account. Must be less than or equal to 256 UTF-8 bytes.
   description: "Description of Service Account"
 
-  # Whether the service account is disabled. Defaults to false.
-  #disabled: false
-
-  # The display name for the service account. Can be updated without creating a new resource.
-  displayName: Example Service Account
-
-  # Immutable. Optional. The accountId of the resource. Used for creation and acquisition.
-  # When unset, the value of `metadata.name` is used as the default.
-  #resourceID: ""
-
 # If keyFile is enabled, Config Connector will create a service account JSON key file and
 # add it to the K8s namespace as a secret called "<service-account-name>-key".
 # In this example the secret will be named "iamserviceaccount-sample-key".


### PR DESCRIPTION
The `iam-service-account` chart now supports Google Workload Identity.

When enabling Workload Identity, a Kubernetes service account with the same name as the IAMServiceAccount will be created together with a IAMPolicyMember resource that enables Workload Identity.

See example below.

```yaml
global:
  # [Required for Workload Identity]
  projectID: my-google-project-id 

name: iamserviceaccount-sample
spec:
  description: "Description of Service Account"

workloadIdentity:
  enabled: true

  # The Kubernetes Namespace your service account is in.
  kubernetesNamespace: default

  # The ID of the Google Cloud Project that contains the Kubernetes cluster.
  gkeProjectID: my-gke-google-project-id
```

# Breaking Changes

The [resourceID](https://github.com/ok-amba/config-connector-helm/blob/iam-service-account-1.1.4/charts/iam-service-account/values.yaml#L39) field has been removed. 
If you are using this field and have a different value than `spec.name` and you update to this version, your IAM Service Account be deleted and recreated with the `spec.name` as resource ID.