### PR TITLE
fix: sql user and policy resource name

### DIFF
--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 2.1.4
+version: 2.1.5

--- a/charts/sqlinstance/templates/iam-partial-policy.yaml
+++ b/charts/sqlinstance/templates/iam-partial-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
-  name: {{ $sa.name | lower | required "Service Account name is required" }}-sqlinstance-roles
+  name: sql-{{ $sa.name | lower | required "Service Account name is required" }}-{{ $.Values.name }}
   {{- if $.Values.argoSyncWave }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}

--- a/charts/sqlinstance/templates/sqluser.yaml
+++ b/charts/sqlinstance/templates/sqluser.yaml
@@ -2,7 +2,7 @@
 apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLUser
 metadata:
-  name: {{ $sa.name | lower | required "Service Account name is required" }}
+  name: {{ $sa.name | lower | required "Service Account name is required" }}-{{ $.Values.name }}
   {{- if or (not $sa.deletionPolicyRemoveResource) ($sa.annotations) ($.Values.argoSyncWave) }}
   annotations:
     {{- with $sa.annotations }}


### PR DESCRIPTION
When using multiple sqlinstances as dependencies in the same Helm chart, the IAMPartialPolicy and SQLUser objects will be named the same in each dependency causing dublicate Kubernetes resources. 
This fix makes them unique to the instance.