### PR TITLE
fix: added object devider for pubsub schema

### DIFF
--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 1.1.2
+version: 1.1.3

--- a/charts/pub-sub/templates/pubsub-schema.yaml
+++ b/charts/pub-sub/templates/pubsub-schema.yaml
@@ -12,4 +12,5 @@ spec:
   definition: | {{ $schema.definition | nindent 4 }}
   projectRef:
     external: {{ $.Values.projectID }}
+---
 {{- end }}


### PR DESCRIPTION
A divider (`---`) was missing in a range in `pubsub-schema.yaml`, which would only deploy the last object defined.