### PR TITLE
feat: added dataset name to table resource name

### DIFF
--- a/charts/big-query/Chart.yaml
+++ b/charts/big-query/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: big-query
 description: A Helm chart for creating Google Cloud Big Query resources.
 type: application
-version: 1.0.0
+version: 1.1.0

--- a/charts/big-query/templates/bq-table.yaml
+++ b/charts/big-query/templates/bq-table.yaml
@@ -3,7 +3,7 @@
 apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
 kind: BigQueryTable
 metadata:
-  name: {{ include "big-query.table-name" . }}
+  name: {{ include "big-query.dataset-name" $dataset }}-{{ include "big-query.table-name" . }}
   annotations:
     cnrm.cloud.google.com/deletion-policy: abandon
   labels:
@@ -22,9 +22,9 @@ spec:
   {{- end }}
 
   {{- if .view }}
-  view: 
+  view:
     useLegacySql: {{ .view.useLegacySql | default false }}
-    query: | {{ .view.query | nindent 6 }} 
+    query: | {{ .view.query | nindent 6 }}
   {{- end }}
 
   {{- if and .timePartitioning (not .view) }}


### PR DESCRIPTION
It is currently not possible to create two tabels with the same name but in two different datasets, because the Kubernetes resource name is the same for both tabels.
This PR appends the dataset name on the Kubernetes table name which would then make the name unique for the dataset.