### PR TITLE
fix: bigquery abandon policy + unit test updates

### DIFF
--- a/charts/big-query/Chart.yaml
+++ b/charts/big-query/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: big-query
 description: A Helm chart for creating Google Cloud Big Query resources.
 type: application
-version: 1.2.0-rc1
+version: 1.2.0

--- a/charts/big-query/templates/bq-table.yaml
+++ b/charts/big-query/templates/bq-table.yaml
@@ -4,8 +4,10 @@ apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
 kind: BigQueryTable
 metadata:
   name: {{ include "big-query.dataset-name" $dataset }}-{{ include "big-query.table-name" . }}
+  {{- if and .schema (not .view) (not .materializedView) }}
   annotations:
     cnrm.cloud.google.com/deletion-policy: abandon
+  {{- end }}
   labels:
     dataset: {{ include "big-query.dataset-name" $dataset }}
     {{- include "big-query.labels" $ | nindent 4 }}

--- a/charts/big-query/tests/dataset_test.yaml
+++ b/charts/big-query/tests/dataset_test.yaml
@@ -1,4 +1,4 @@
-# https://github.com/helm-unittest/helm-unittest 
+# https://github.com/helm-unittest/helm-unittest
 suite: Big Query Dataset
 templates:
   - bq-dataset.yaml
@@ -36,16 +36,19 @@ tests:
   - it: Should set the Config Connector SA to owner on Dataset
     set:
       global.projectID: some-project-id
-      configConnectorSaId: cc-service-account
+      configConnectorSaId: cc-service-account@some-project-id.iam.gserviceaccount.com
       dataSets.dataSetShortName01:
         name: some-dataset-name
     asserts:
-      - equal:
-          path: spec.access[0].role
-          value: OWNER
-      - equal:
-          path: spec.access[0].userByEmail
-          value: cc-service-account@some-project-id.iam.gserviceaccount.com
+      - lengthEqual:
+          path: spec.access
+          count: 1
+      - contains:
+          path: spec.access
+          count: 1
+          content:
+            role: OWNER
+            userByEmail: cc-service-account@some-project-id.iam.gserviceaccount.com
 
   - it: Should set READER and WRITER permissions on service account name
     set:
@@ -59,18 +62,27 @@ tests:
           reader:
             - some-sa-name
     asserts:
-      - equal:
-          path: spec.access[1].role
-          value: WRITER
-      - equal:
-          path: spec.access[1].userByEmail
-          value: some-sa-name@some-project-id.iam.gserviceaccount.com
-      - equal:
-          path: spec.access[2].role
-          value: READER
-      - equal:
-          path: spec.access[2].userByEmail
-          value: some-sa-name@some-project-id.iam.gserviceaccount.com
+      - lengthEqual:
+          path: spec.access
+          count: 3
+      - contains:
+          path: spec.access
+          count: 1
+          content:
+            role: OWNER
+            userByEmail: some-service-account-name
+      - contains:
+          path: spec.access
+          count: 1
+          content:
+            role: WRITER
+            userByEmail: some-sa-name@some-project-id.iam.gserviceaccount.com
+      - contains:
+          path: spec.access
+          count: 1
+          content:
+            role: READER
+            userByEmail: some-sa-name@some-project-id.iam.gserviceaccount.com
 
   - it: Should set READER and WRITER permissions on external service account name
     set:
@@ -84,23 +96,26 @@ tests:
           externalReader:
             - some-sa-name@some-project-id.iam.gserviceaccount.com
     asserts:
-      - equal:
-          path: spec.access[1].role
-          value: WRITER
-      - equal:
-          path: spec.access[1].userByEmail
-          value: some-sa-name@some-project-id.iam.gserviceaccount.com
-      - equal:
-          path: spec.access[2].role
-          value: READER
-      - equal:
-          path: spec.access[2].userByEmail
-          value: some-sa-name@some-project-id.iam.gserviceaccount.com
+      - lengthEqual:
+          path: spec.access
+          count: 3
+      - contains:
+          path: spec.access
+          count: 1
+          content:
+            role: WRITER
+            userByEmail: some-sa-name@some-project-id.iam.gserviceaccount.com
+      - contains:
+          path: spec.access
+          count: 1
+          content:
+            role: READER
+            userByEmail: some-sa-name@some-project-id.iam.gserviceaccount.com
 
-  - it: Should NOT give any of the given users access, sinces they do not meet the regexMatch
+  - it: Should NOT give any of the given users access, sinces they do not meet the regexMatch requirements
     set:
       global.projectID: some-project-id
-      configConnectorSaId: some-service-account-name
+      configConnectorSaId: some-service-account-name@some-project-id.iam.gserviceaccount.com
       dataSets.dataSetShortName01:
           name: some-dataset-name
           permissions:
@@ -112,11 +127,14 @@ tests:
               - some-name
             writer:
               - some-name@other-domain.com
-              - some-name@some-project-id.iam.gserviceaccount.com 
+              - some-name@some-project-id.iam.gserviceaccount.com
             reader:
               - some-name@other-domain.com
-              - some-name@some-project-id.iam.gserviceaccount.com 
+              - some-name@some-project-id.iam.gserviceaccount.com
     asserts:
+      - lengthEqual:
+          path: spec.access
+          count: 1
       - contains:
           path: spec.access
           content:

--- a/charts/big-query/tests/table_test.yaml
+++ b/charts/big-query/tests/table_test.yaml
@@ -77,3 +77,123 @@ tests:
       - isNull:
           path: spec.timePartitioning
 
+  - it: Should add the abandon annotation on tables/schemas
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+        tables:
+          - name: some-table-name
+            schema: |
+              [
+                {
+                  "mode": "NULLABLE",
+                  "name": "ColumnName01",
+                  "type": "STRING"
+                }
+              ]
+    asserts:
+      - equal:
+          path: metadata.annotations["cnrm.cloud.google.com/deletion-policy"]
+          value: abandon
+
+  - it: Should NOT add the abandon annotation on materializedView
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+        tables:
+          - name: some-table-name
+            materializedView:
+              query: some-query
+    asserts:
+      - isNull:
+          path: metadata.annotations["cnrm.cloud.google.com/deletion-policy"]
+
+  - it: Should NOT add the abandon annotation on views
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+        tables:
+          - name: some-table-name
+            view:
+              query: some-query
+    asserts:
+      - isNull:
+          path: metadata.annotations["cnrm.cloud.google.com/deletion-policy"]
+
+  - it: materializedView should take precedence over shema + timePartitioning
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+        tables:
+          - name: some-table-name
+            materializedView:
+              query: some-query
+            schema: |
+              [
+                {
+                  "mode": "NULLABLE",
+                  "name": "ColumnName01",
+                  "type": "STRING"
+                }
+              ]
+            timePartitioning:
+              field: ReadOn
+              requirePartitionFilter: false
+              type: DAY
+    asserts:
+      - isNull:
+          path: spec.schema
+      - isNull:
+          path: spec.timePartitioning
+
+  - it: view should take precedence over shema + timePartitioning
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+        tables:
+          - name: some-table-name
+            view:
+              query: some-query
+            schema: |
+              [
+                {
+                  "mode": "NULLABLE",
+                  "name": "ColumnName01",
+                  "type": "STRING"
+                }
+              ]
+            timePartitioning:
+              field: ReadOn
+              requirePartitionFilter: false
+              type: DAY
+    asserts:
+      - isNull:
+          path: spec.schema
+      - isNull:
+          path: spec.timePartitioning
+
+  - it: view should take precedence over materializedView
+    set:
+      global.projectID: some-project-id
+      configConnectorSaId: cc-service-account
+      dataSets.dataSetShortName01:
+        name: some-dataset-name
+        tables:
+          - name: some-table-name
+            materializedView:
+              query: some-query
+            view:
+              query: some-query
+    asserts:
+      - isNull:
+          path: spec.materializedView


### PR DESCRIPTION
The `cnrm.cloud.google.com/deletion-policy: abandon`  is only applied of the BigQueryTable if there's a schema and not on Views or Materialized Views.

Unit test are fitted appropriately.