### PR TITLE
feat: sqlinstance v3.0.0

### DIFF
--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 2.1.5
+version: 3.0.0-rc1

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -6,3 +6,39 @@ chart-version: {{ .Chart.Version | replace "." "-" }}
 {{ printf "%s: %s" $k ($v | quote) }}
 {{- end -}}
 {{- end -}}
+
+##########################################################
+#                   Calculate work_mem                   #
+##########################################################
+# This function calulates the "work_mem" db flag value.
+# The default value for Micro and Small instances
+# is 4096.
+{{- define "sqlinstance.work-mem" -}}
+{{ $work_mem := "4096" }}
+{{- if and (ne .Values.tier "db-f1-micro") (ne .Values.tier "db-g1-small") }}
+  {{- $instance_mem := regexFind "\\d{4,}" .Values.tier | int }}
+  {{- $connections := 0 -}}
+
+  {{- if lt $instance_mem 6144}}
+  {{- $connections = 100 }}
+  {{- else if lt $instance_mem 7680 }}
+  {{- $connections = 200 }}
+  {{- else if lt $instance_mem 15360 }}
+  {{- $connections = 400 }}
+  {{- else if lt $instance_mem 30720 }}
+  {{- $connections = 500 }}
+  {{- else if lt $instance_mem 61440 }}
+  {{- $connections = 600 }}
+  {{- else if lt $instance_mem 122880 }}
+  {{- $connections = 800 }}
+  {{- else if gt $instance_mem 122880 }}
+  {{- $connections = 1000 }}
+  {{- else }}
+  {{- fail (printf "could not calculate instance memory for instance flag work_mem. memory: [%s] " $instance_mem) -}}
+  {{- end -}}
+
+  {{/* Total RAM * 0.25 / max_connections. Eg 3750*0.25/100 = 9,375 */}}
+  {{- $work_mem = mulf (divf (mulf $instance_mem 0.25) $connections) 1000 }}
+{{- end -}}
+{{ $work_mem | quote }}
+{{- end -}}

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 app: {{ .Release.Name }}
 chart-name: {{ .Chart.Name }}
 chart-version: {{ .Chart.Version | replace "." "-" }}
-{{- with .Values.global.labels }}
-{{- toYaml . | nindent 0 }}
+{{- range $k, $v := .Values.global.labels }}
+{{ printf "%s: %s" $k ($v | quote) }}
 {{- end -}}
 {{- end -}}

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -42,3 +42,19 @@ chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- end -}}
 {{ $work_mem | quote }}
 {{- end -}}
+
+##########################################################
+#                      Validate Tier                     #
+##########################################################
+# This function validates that the MiB of the custom tier
+# selected is multiple of 256. Micro and Small tier will
+# not be evaluated.
+{{- define "sqlinstance.validate-tier" -}}
+{{- if and (ne .Values.tier "db-f1-micro") (ne .Values.tier "db-g1-small") }}
+  {{- $instance_mem := regexFind "\\d{4,}" .Values.tier | int }}
+  {{- if mod $instance_mem 256 }}
+  {{- fail (printf "the total memory [%dMiB] must be a multiple of 256 MiB. " $instance_mem) -}}
+  {{- end -}}
+{{- end -}}
+{{ .Values.tier }}
+{{- end -}}

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -58,3 +58,22 @@ chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- end -}}
 {{ .Values.tier }}
 {{- end -}}
+
+##########################################################
+#              Validate Availability Setting             #
+##########################################################
+# Validates that .availabilityType is either REGIONAL or
+# ZONAL. Also validates that .backupConfiguration.enabled
+# and .backupConfiguration.pointInTimeRecoveryEnabled
+# is true if .availabilityType is REGIONAL.
+{{- define "sqlinstance.validate-availability-type" -}}
+{{- if and (ne .Values.availabilityType "REGIONAL") (ne .Values.availabilityType "ZONAL")}}
+  {{- fail (printf "'.availabilityType' must be either REGIONAL or ZONAL") -}}
+{{- end -}}
+
+{{- if eq .Values.availabilityType "REGIONAL" }}
+  {{- if or (not .Values.backupConfiguration.enabled) (not .Values.backupConfiguration.pointInTimeRecoveryEnabled) }}
+    {{- fail (printf "if '.availabilityType' is REGIONAL, then '.backupConfiguration.enabled' and '.backupConfiguration.pointInTimeRecoveryEnabled' must be true.") -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sqlinstance/templates/iam-partial-policy.yaml
+++ b/charts/sqlinstance/templates/iam-partial-policy.yaml
@@ -9,8 +9,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "sqlinstance.labels" $ | nindent 4 }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
   resourceRef:

--- a/charts/sqlinstance/templates/iam-partial-policy.yaml
+++ b/charts/sqlinstance/templates/iam-partial-policy.yaml
@@ -1,8 +1,8 @@
 {{ range $sa := .Values.serviceAccounts }}
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPartialPolicy
+kind: IAMPolicyMember
 metadata:
-  name: sql-{{ $sa.name | lower | required "Service Account name is required" }}-{{ $.Values.name }}
+  name: sql-{{ $sa.name }}-{{ $.Values.name }}
   {{- if $.Values.argoSyncWave }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
@@ -16,16 +16,11 @@ spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
-    external: projects/{{ $sa.projectId | lower | required "A project ID is required" }}
-  bindings:
-    {{- if $sa.role }}
-    - role: {{ $sa.role }}
-    {{- else }}
-    - role: organizations/909834982171/roles/cloudsql.serviceaccount.access
-    {{- end }}
-      members:
-        - memberFrom:
-            serviceAccountRef:
-              name: {{ $sa.name | lower | required "Service Account name is required" }}
+    external: "projects/{{ $.Values.global.projectID }}"
+  role: organizations/909834982171/roles/cloudsql.serviceaccount.access
+  memberFrom:
+    serviceAccountRef:
+      name: {{ $sa.name }}
 ---
 {{- end }}
+

--- a/charts/sqlinstance/templates/sqldatabase.yaml
+++ b/charts/sqlinstance/templates/sqldatabase.yaml
@@ -10,8 +10,8 @@ metadata:
     {{- end }}
   labels:
     {{- include "sqlinstance.labels" $ | nindent 4 }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
   charset: UTF8
@@ -40,8 +40,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "sqlinstance.labels" $ | nindent 4 }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
   charset: {{ ($db.spec).charset | default "UTF8" }}

--- a/charts/sqlinstance/templates/sqlinstance.yaml
+++ b/charts/sqlinstance/templates/sqlinstance.yaml
@@ -2,6 +2,8 @@
 {{- fail (printf "you have not given your sqlinstance a proper name. [%s] " .Values.name) -}}
 {{- end -}}
 
+{{- include "sqlinstance.validate-availability-type" $ }}
+
 apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
@@ -27,7 +29,7 @@ spec:
   databaseVersion: {{ .Values.databaseVersion }}
   region: europe-west3
   settings:
-    availabilityType: REGIONAL
+    availabilityType: {{ .Values.availabilityType }}
     tier: {{ include "sqlinstance.validate-tier" $ }}
 
     {{- with .Values.backupConfiguration }}

--- a/charts/sqlinstance/templates/sqlinstance.yaml
+++ b/charts/sqlinstance/templates/sqlinstance.yaml
@@ -16,8 +16,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "sqlinstance.labels" . | nindent 4 }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
   {{- with .Values.spec }}

--- a/charts/sqlinstance/templates/sqlinstance.yaml
+++ b/charts/sqlinstance/templates/sqlinstance.yaml
@@ -24,6 +24,42 @@ metadata:
     {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .Values.spec }}
-    {{- toYaml . | nindent 2 }}
-  {{- end }}
+  databaseVersion: {{ .Values.databaseVersion }}
+  region: europe-west3
+  settings:
+    availabilityType: REGIONAL
+    tier: {{ include "sqlinstance.validate-tier" $ }}
+
+    {{- with .Values.backupConfiguration }}
+    backupConfiguration:
+      backupRetentionSettings:
+        retainedBackups: {{ .backupRetentionSettings.retainedBackups}}
+      enabled: {{ .enabled }}
+      location: eu
+      pointInTimeRecoveryEnabled: {{ .pointInTimeRecoveryEnabled }}
+      startTime: {{ .startTime }}
+      transactionLogRetentionDays: {{ .transactionLogRetentionDays }}
+    {{- end }}
+
+    {{- with .Values.insightsConfig }}
+    insightsConfig:
+      queryInsightsEnabled: {{ .queryInsightsEnabled }}
+      recordApplicationTags: {{ .recordApplicationTags }}
+      recordClientAddress: {{ .recordClientAddress }}
+    {{- end }}
+
+    {{- with .Values.maintenanceWindow }}
+    maintenanceWindow:
+      day: {{ .day }}
+      hour: {{ .hour }}
+      updateTrack: {{ .updateTrack }}
+    {{- end }}
+    databaseFlags:
+      - name: cloudsql.iam_authentication
+        value: "on"
+      - name: work_mem
+        value: {{ include "sqlinstance.work-mem" $ }}
+      {{- range $name, $value := .Values.databaseFlags }}
+      - name: {{ $name }}
+        value: {{ $value | quote }}
+      {{- end }}

--- a/charts/sqlinstance/templates/sqlinstance.yaml
+++ b/charts/sqlinstance/templates/sqlinstance.yaml
@@ -1,3 +1,7 @@
+{{- if eq .Values.name "sqlinstance-sample" -}}
+{{- fail (printf "you have not given your sqlinstance a proper name. [%s] " .Values.name) -}}
+{{- end -}}
+
 apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:

--- a/charts/sqlinstance/templates/sqluser.yaml
+++ b/charts/sqlinstance/templates/sqluser.yaml
@@ -1,8 +1,9 @@
 {{- range $sa := .Values.serviceAccounts }}
+{{ $name := $sa.name | lower | required "Service Account name is required" }}
 apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLUser
 metadata:
-  name: {{ $sa.name | lower | required "Service Account name is required" }}-{{ $.Values.name }}
+  name: {{ $name }}-{{ $.Values.name }}
   {{- if or (not $sa.deletionPolicyRemoveResource) ($sa.annotations) ($.Values.argoSyncWave) }}
   annotations:
     {{- with $sa.annotations }}
@@ -21,12 +22,9 @@ metadata:
     {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if ($sa.spec).host }}
-  host: {{ $sa.spec.host }}
-  {{- end }}
   type: CLOUD_IAM_SERVICE_ACCOUNT
   instanceRef:
-    name: {{ $.Values.name | lower | required "instanceRef name required" }}
-  resourceID: {{ $sa.name | lower | required "Service Account name is required" }}@{{ $sa.projectId | lower | required "A project ID is required" }}.iam
+    name: {{ $.Values.name }}
+  resourceID: {{ $name  }}@{{ $.Values.global.projectID | required "A project ID is required" }}.iam
 ---
 {{- end }}

--- a/charts/sqlinstance/templates/sqluser.yaml
+++ b/charts/sqlinstance/templates/sqluser.yaml
@@ -17,8 +17,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "sqlinstance.labels" $ | nindent 4 }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
   {{- if ($sa.spec).host }}

--- a/charts/sqlinstance/values.yaml
+++ b/charts/sqlinstance/values.yaml
@@ -9,6 +9,9 @@ global:
   # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
+  # The Google Project ID.
+  projectID: null
+
 ######################################################
 #                    SQL Instance                    #
 ######################################################
@@ -29,38 +32,36 @@ labels: {}
 # Annotations on the Config Connector resource.
 annotations: {}
 
-spec:
-  databaseVersion: POSTGRES_14
-  region: europe-west3
-  settings:
-    backupConfiguration:
-      backupRetentionSettings:
-        retainedBackups: 8
-      enabled: true
-      location: eu
-      pointInTimeRecoveryEnabled: true
-      startTime: 01:00
-      transactionLogRetentionDays: 7
-    insightsConfig:
-      queryInsightsEnabled: true
-      recordApplicationTags: true
-      recordClientAddress: true
-    maintenanceWindow:
-      day: 7
-      hour: 02
-      updateTrack: stable
-    availabilityType: REGIONAL
-    databaseFlags:
-    - name: cloudsql.iam_authentication
-      value: "on"
-    tier: db-f1-micro
+databaseVersion: POSTGRES_15
+tier: db-f1-micro
 
+availabilityType: REGIONAL
+backupConfiguration:
+  backupRetentionSettings:
+    retainedBackups: 8
+  enabled: true
+  pointInTimeRecoveryEnabled: true
+  startTime: 01:00
+  transactionLogRetentionDays: 7
+
+insightsConfig:
+  queryInsightsEnabled: true
+  recordApplicationTags: true
+  recordClientAddress: true
+
+maintenanceWindow:
+  day: 7
+  hour: 02
+  updateTrack: stable
+
+# NB: Some database flags will force a reboot of the Instance.
+# https://cloud.google.com/sql/docs/postgres/flags
+databaseFlags: []
+  # cloudsql.logical_decoding: "on"
 
 ######################################################
 #                     Databases                      #
 ######################################################
-
-# https://cloud.google.com/config-connector/docs/reference/resource-docs/sql/sqldatabase
 
 # If you leave the "databases" array empty, a default database with the same name as the SQL Instance will be created, with default values.
 # If you want another database name or create multiple datebases, add them to the array below with minimum a name. Examples are provided.
@@ -88,10 +89,8 @@ databases: []
 # You can how ever change the default OK amba custom role by setting the "role" property.
 serviceAccounts: []
   # - name: my-service-account
-  #   projectId: my-google-project-id
-
+  #
   #   # Below values are optional
-  #   role: your-google-role-here
   #   deletionPolicyRemoveResource: true
   #   annotations:
   #     some-annotation: some-value

--- a/charts/sqlinstance/values.yaml
+++ b/charts/sqlinstance/values.yaml
@@ -35,7 +35,10 @@ annotations: {}
 databaseVersion: POSTGRES_15
 tier: db-f1-micro
 
+# Possible values are REGIONAL for high availability or ZONAL for a single zone instance.
+# Recommendation id to use REGIONAL for production use and ZONAL for test.
 availabilityType: REGIONAL
+
 backupConfiguration:
   backupRetentionSettings:
     retainedBackups: 8


### PR DESCRIPTION
- Added quotes on all labels.
- Update `databaseVersion` to `POSTGRES_15`
- The `.spec` property is no longer a 1:1 replica of the Config Connector object spec. Settings for the SQL instance is explicitly supported.
- Database flags are no longer overwritten.
  - `cloudsql.iam_authentication` is always `on`.
  - `work_mem` is set and calculated based on `.tier`
- `.tier` is validated that instance memory is modulo of 256 (MiB)
- `IAMPartialPolicy` is replaced with `IAMPolicyMember`. Functionality remains the same.
- Removed MySQL host option from `SQLUser`.
- Added a check that prevents the sqlinstance name `sqlinstance-sample` to reduce ghost instances.
- Removed the option to add custom roles for the service account.
- Removed the option to add an `SQLUser` from another Google Project.
- Added the `.global.projectID` property to comply with the other Helm Chart standards.
- Added checks for `.availablilityType`.
  - Can only be either `REGIONAL` or `ZONAL`.
  - If `REGIONAL`, both `.backupConfiguration.enabled` and `.backupConfiguration.pointInTimeRecoveryEnabled` must be true.
