### PR TITLE
chore: version bump

### DIFF
--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 3.0.0-rc1
+version: 3.0.0


### PR DESCRIPTION
Updated the `sqlinstance` chart to `3.0.0`.