### PR TITLE
Feat/remove support for multiple sa

### DIFF
--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 3.0.0-rc1
+version: 3.0.0

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -2,6 +2,7 @@
 app: {{ .Release.Name }}
 chart-name: {{ .Chart.Name }}
 chart-version: {{ .Chart.Version | replace "." "-" }}
+sqlinstance: {{ .Values.name }}
 {{- range $k, $v := .Values.global.labels }}
 {{ printf "%s: %s" $k ($v | quote) }}
 {{- end -}}

--- a/charts/sqlinstance/templates/iam-policy-member.yaml
+++ b/charts/sqlinstance/templates/iam-policy-member.yaml
@@ -1,11 +1,11 @@
-{{ range $sa := .Values.serviceAccounts }}
+{{- if .Values.serviceAccountName }}
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: sql-{{ $sa.name }}-{{ $.Values.name }}
-  {{- if $.Values.argoSyncWave }}
+  name: sqluser-{{ .Values.serviceAccountName }}
+  {{- if .Values.argoSyncWave }}
   annotations:
-    argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | quote }}
   {{- end }}
   labels:
     {{- include "sqlinstance.labels" $ | nindent 4 }}
@@ -16,11 +16,11 @@ spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
-    external: "projects/{{ $.Values.global.projectID }}"
+    external: "projects/{{ .Values.global.projectID }}"
   role: organizations/909834982171/roles/cloudsql.serviceaccount.access
   memberFrom:
     serviceAccountRef:
-      name: {{ $sa.name }}
+      name: {{ .Values.serviceAccountName }}
 ---
 {{- end }}
 

--- a/charts/sqlinstance/templates/sqluser.yaml
+++ b/charts/sqlinstance/templates/sqluser.yaml
@@ -1,21 +1,13 @@
-{{- range $sa := .Values.serviceAccounts }}
-{{ $name := $sa.name | lower | required "Service Account name is required" }}
+{{- if .Values.serviceAccountName }}
 apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLUser
 metadata:
-  name: {{ $name }}-{{ $.Values.name }}
-  {{- if or (not $sa.deletionPolicyRemoveResource) ($sa.annotations) ($.Values.argoSyncWave) }}
+  name: {{ .Values.serviceAccountName }}
   annotations:
-    {{- with $sa.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if not $sa.deletionPolicyRemoveResource }}
     cnrm.cloud.google.com/deletion-policy: abandon
+    {{- if .Values.argoSyncWave }}
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | quote }}
     {{- end }}
-    {{- if $.Values.argoSyncWave }}
-    argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
-    {{- end }}
-  {{- end }}
   labels:
     {{- include "sqlinstance.labels" $ | nindent 4 }}
     {{- range $k, $v := $.Values.labels }}
@@ -24,7 +16,7 @@ metadata:
 spec:
   type: CLOUD_IAM_SERVICE_ACCOUNT
   instanceRef:
-    name: {{ $.Values.name }}
-  resourceID: {{ $name  }}@{{ $.Values.global.projectID | required "A project ID is required" }}.iam
+    name: {{ .Values.name }}
+  resourceID: {{ .Values.serviceAccountName }}@{{ .Values.global.projectID | required "A project ID is required" }}.iam
 ---
 {{- end }}

--- a/charts/sqlinstance/values.yaml
+++ b/charts/sqlinstance/values.yaml
@@ -35,6 +35,10 @@ annotations: {}
 databaseVersion: POSTGRES_15
 tier: db-f1-micro
 
+# The name of the service account that gets access to the SQL Instance.
+# This referes to the id of the SA without the "@<projectid>.iam.gserviceaccount.com"
+serviceAccountName: null
+
 # Possible values are REGIONAL for high availability or ZONAL for a single zone instance.
 # Recommendation id to use REGIONAL for production use and ZONAL for test.
 availabilityType: REGIONAL
@@ -79,21 +83,3 @@ databases: []
   #   spec:
   #     charset: some-other-value
   #     collation: some-other-value
-
-
-######################################################
-#                   Databases Users                  #
-######################################################
-
-# https://cloud.google.com/config-connector/docs/reference/resource-docs/sql/sqluser
-
-# Below array hold the service accounts which should get access.
-# The SA will get the necessary roles to be able to connect using Cloud SQL Proxy and write to the DB.
-# You can how ever change the default OK amba custom role by setting the "role" property.
-serviceAccounts: []
-  # - name: my-service-account
-  #
-  #   # Below values are optional
-  #   deletionPolicyRemoveResource: true
-  #   annotations:
-  #     some-annotation: some-value


### PR DESCRIPTION
This is a missing change to the v3.0.0 PR, https://github.com/ok-amba/config-connector-helm/pull/22

Removed support for adding multiple service accounts as SQL users.