### PR TITLE
feat: pub-sub chart v2.0.0 release candidate update

### DIFF
--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 1.1.3
+version: 2.0.0-rc1

--- a/charts/pub-sub/templates/_helpers.tpl
+++ b/charts/pub-sub/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{- define "pubsub.labels" -}}
-app: {{ .Release.Name }}
-chart-name: {{ .Chart.Name }}
-chart-version: {{ .Chart.Version | replace "." "-" }}
-{{- with .Values.global.labels }}
-  {{- toYaml . }}
+app: "{{ .Release.Name }}"
+chart-name: "{{ .Chart.Name }}"
+chart-version: "{{ .Chart.Version | replace "." "-" }}"
+{{- range $k, $v := .Values.global.labels }}
+{{ printf "%s: %s" $k ($v | quote) }}
 {{- end -}}
 {{- end -}}

--- a/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
+++ b/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
@@ -21,8 +21,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
   resourceRef:
@@ -75,8 +75,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
   resourceRef:

--- a/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
+++ b/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
@@ -10,15 +10,11 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
   name: "pub-role-{{ $topic.name }}"
-  {{- if or ($.Values.annotations) ($.Values.argoSyncWave) }}
   annotations:
-    {{- with $.Values.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if $.Values.argoSyncWave }}
     argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
     {{- range $k, $v := $.Values.labels }}
@@ -64,15 +60,11 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
   name: "sub-role-{{ $sub.name }}"
-  {{- if or ($.Values.annotations) ($.Values.argoSyncWave) }}
   annotations:
-    {{- with $.Values.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if $.Values.argoSyncWave }}
     argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
     {{- range $k, $v := $.Values.labels }}

--- a/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
+++ b/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
@@ -1,6 +1,7 @@
 ############################################################
 #                PubSub IAM Partial Policy                 #
 ############################################################
+{{- required ".global.projectID is required." .Values.global.projectID }}
 
 {{- range $topic := .Values.topics  }}
 {{- if or $topic.publishers $topic.isDeadletterTopic $.Values.globalPublishers }}
@@ -32,11 +33,23 @@ spec:
     - role: roles/pubsub.publisher
       members:
         {{- if $topic.isDeadletterTopic }}
-        - member: "serviceAccount:service-{{ $.Values.projectNumber }}@gcp-sa-pubsub.iam.gserviceaccount.com"
-        {{- else }}
+          {{- $projectNumber := $.Values.global.projectNumber | int64 }}
+          {{- if eq $projectNumber 0 }}
+          {{- fail (printf ".global.projectNumber is not set or is invalid.") -}}
+          {{- end }}
+        - member: "serviceAccount:service-{{ $projectNumber }}@gcp-sa-pubsub.iam.gserviceaccount.com"
+        {{- else -}}
+
+        {{/* Below logic merges the internal globalPublishers and the publishers on a topic*/}}
         {{- $publishers := concat  ($topic.publishers | default list) $.Values.globalPublishers | uniq }}
-        {{- range $sa := $publishers  }}
-        - member:  "serviceAccount:{{ $sa }}"
+        {{- range $sa := $publishers }}
+        - member: "serviceAccount:{{ $sa }}@{{ $.Values.global.projectID }}.iam.gserviceaccount.com"
+        {{- end -}}
+
+        {{/* Below logic merges the externalGlobalPublishers and the externalPublishers on a topic*/}}
+        {{- $externalPublishers := concat  ($topic.externalPublishers | default list) $.Values.externalGlobalPublishers | uniq }}
+        {{- range $sa := $externalPublishers }}
+        - member: "serviceAccount:{{ $sa }}"
         {{- end }}
         {{- end }}
 
@@ -73,12 +86,24 @@ spec:
   bindings:
     - role: roles/pubsub.subscriber
       members:
+        {{- if $sub.spec.deadLetterPolicy }}
+          {{- $projectNumber := $.Values.global.projectNumber | int64 }}
+          {{- if eq $projectNumber 0 }}
+          {{- fail (printf ".global.projectNumber is not set or is invalid.") -}}
+          {{- end }}
+        - member:  "serviceAccount:service-{{ $projectNumber }}@gcp-sa-pubsub.iam.gserviceaccount.com"
+        {{- end -}}
+
+        {{/* Below logic merges the internal globalSubscribers and the subscribers on a subscription */}}
         {{- $subscribers := concat  ($sub.subscribers | default list) $.Values.globalSubscribers | uniq }}
         {{- range $sa := $subscribers }}
+        - member:  "serviceAccount:{{ $sa }}@{{ $.Values.global.projectID }}.iam.gserviceaccount.com"
+        {{- end -}}
+
+        {{/* Below logic merges the externalGlobalSubscribers and the externalSubscribers on a subscription */}}
+        {{- $externalSubscribers := concat  ($sub.externalSubscribers | default list) $.Values.externalGlobalSubscribers | uniq }}
+        {{- range $sa := $externalSubscribers }}
         - member:  "serviceAccount:{{ $sa }}"
-        {{- end }}
-        {{- if $sub.spec.deadLetterPolicy }}
-        - member:  "serviceAccount:service-{{ $.Values.projectNumber }}@gcp-sa-pubsub.iam.gserviceaccount.com"
         {{- end }}
 ---
 {{- end }}

--- a/charts/pub-sub/templates/pubsub-schema.yaml
+++ b/charts/pub-sub/templates/pubsub-schema.yaml
@@ -7,6 +7,11 @@ apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
 kind: PubSubSchema
 metadata:
   name: {{ $schema.name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
     {{- range $k, $v := $.Values.labels }}

--- a/charts/pub-sub/templates/pubsub-schema.yaml
+++ b/charts/pub-sub/templates/pubsub-schema.yaml
@@ -11,6 +11,6 @@ spec:
   type: {{ $schema.type }}
   definition: | {{ $schema.definition | nindent 4 }}
   projectRef:
-    external: {{ $.Values.projectID }}
+    external: {{ $.Values.global.projectID }}
 ---
 {{- end }}

--- a/charts/pub-sub/templates/pubsub-schema.yaml
+++ b/charts/pub-sub/templates/pubsub-schema.yaml
@@ -7,6 +7,11 @@ apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
 kind: PubSubSchema
 metadata:
   name: {{ $schema.name }}
+  labels:
+    {{- include "pubsub.labels" $ | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ $schema.type }}
   definition: | {{ $schema.definition | nindent 4 }}

--- a/charts/pub-sub/templates/pubsub-subscription.yaml
+++ b/charts/pub-sub/templates/pubsub-subscription.yaml
@@ -23,8 +23,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 spec:
 {{- deepCopy $.Values.globalSubscriptionSpecs | merge $sub.spec | toYaml | nindent 2 }}

--- a/charts/pub-sub/templates/pubsub-subscription.yaml
+++ b/charts/pub-sub/templates/pubsub-subscription.yaml
@@ -12,15 +12,11 @@ apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
 kind: PubSubSubscription
 metadata:
   name: {{ $sub.name }}
-  {{- if or ($.Values.annotations) ($.Values.argoSyncWave) }}
   annotations:
-    {{- with $.Values.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if $.Values.argoSyncWave }}
     argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
     {{- range $k, $v := $.Values.labels }}

--- a/charts/pub-sub/templates/pubsub-topic.yaml
+++ b/charts/pub-sub/templates/pubsub-topic.yaml
@@ -23,8 +23,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
-    {{- with $.Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := $.Values.labels }}
+    {{- printf "%s: %s" $k ($v | quote) | nindent 4 }}
     {{- end }}
 {{- with $topic }}
 {{- if or .messageRetentionDuration .schemaNameRef }}

--- a/charts/pub-sub/templates/pubsub-topic.yaml
+++ b/charts/pub-sub/templates/pubsub-topic.yaml
@@ -12,15 +12,11 @@ apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
 kind: PubSubTopic
 metadata:
   name: {{ $topic.name }}
-  {{- if or ($.Values.annotations) ($.Values.argoSyncWave) }}
   annotations:
-    {{- with $.Values.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if $.Values.argoSyncWave }}
     argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- end }}
   labels:
     {{- include "pubsub.labels" $ | nindent 4 }}
     {{- range $k, $v := $.Values.labels }}

--- a/charts/pub-sub/values.yaml
+++ b/charts/pub-sub/values.yaml
@@ -9,17 +9,17 @@ global:
   # Google Cloud labels only support hyphens (-), underscores (_), lowercase characters and numbers.
   labels: {}
 
+  # The Google Project ID.
+  # [Required]
+  projectID: null
+
+  # Google project number, not the ID. This is used to give the default pubsub service account
+  # access to deadletter topics. Get a list with the "gcloud projects list" command.
+  projectNumber: null
+
 # Below property sets a ArgoCD Sync Wave annotation on all resources. Set it to "false" to disable it.
 # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/
 argoSyncWave: -5
-
-# Google project ID, this property is only needed if you are creating Topic Schemas.
-# This should be set in each environment values file.
-projectID: set-in-environment-values-file
-
-# Google project number, not the ID. This is used to give the default pubsub service account
-# access to deadletter topics. Get a list with the "gcloud projects list" command.
-projectNumber: "123456789"
 
 # Below labels and annotations will be set on all resources.
 annotations: {}

--- a/charts/pub-sub/values.yaml
+++ b/charts/pub-sub/values.yaml
@@ -36,11 +36,11 @@ labels: {}
 
 # A list of service accounts names without the "@<projectid>.iam.gserviceaccount.com" belonging to your Google project.
 globalPublishers: []
-  # - global-user
+  # - <service-account>
 
 # A list of service accounts using the full ID. Used for services accounts outside your Google project.
 externalGlobalPublishers: []
-  # - external-global@some-other-project.iam.gserviceaccount.com
+  # - <service-account-name>@<project-id>.iam.gserviceaccount.com
 
 topics: {}
   # # The "topicShortName01" is not used for anything other than for you to reference in an environment values file.

--- a/charts/pub-sub/values.yaml
+++ b/charts/pub-sub/values.yaml
@@ -33,26 +33,36 @@ labels: {}
 
 # Global publishers will get the publisher role on all topics in this chart, except deadletter topics.
 # The list will be merged with the publishers set on each specific topic.
+
+# A list of service accounts names without the "@<projectid>.iam.gserviceaccount.com" belonging to your Google project.
 globalPublishers: []
-  # - <service-account-name>@<my-project-id>.iam.gserviceaccount.com
+  # - global-user
+
+# A list of service accounts using the full ID. Used for services accounts outside your Google project.
+externalGlobalPublishers: []
+  # - external-global@some-other-project.iam.gserviceaccount.com
 
 topics: {}
   # # The "topicShortName01" is not used for anything other than for you to reference in an environment values file.
   # # Each short name must be unique.
   # topicShortName01:
   #   name: my-topic-name-01
-
+  #
   #   # Set below property to true to create the necessary policy bindings for a deadletter topic.
   #   # (The default pubsub service account will get publisher role)
   #   isDeadletterTopic: false
-
+  #
   #   # When enabled, retains messages on the Topic for up to 31 days after they get acknowledged. This feature is not free.
   #   # Cannot be more than 31 days or less than 10 minutes. Value is en seconds and ends with "s" eg. "600s".
   #   messageRetentionDuration: null
-
-  #   # A list of full service accounts ID's to get the publisher role on this topic.
-  #   publishers:
-  #     - <some-other-service-account-name>@<my-project-id>.iam.gserviceaccount.com
+  #
+  #   # A list of service accounts names without the "@<projectid>.iam.gserviceaccount.com" belonging to your Google project.
+  #   publishers: []
+  #     # - <service-account>
+  #
+  #   # A list of service accounts using the full ID. Used for services accounts outside your Google project.
+  #   externalPublishers: []
+  #     # - <service-account>@<project-id>.iam.gserviceaccount.com
 
   # # Below example is a minumum configuration of a topic. No deadletter topic or no messageRetentionDuration.
   # topicShortName02:
@@ -75,7 +85,11 @@ topics: {}
 
 # Below list of service account ID's will be given the subscriber role on all subscriptions.
 globalSubscribers: []
-  # - <service-account-name>@<my-project-id>.iam.gserviceaccount.com
+  # - <service-account>
+
+# Below list of service account ID's will be given the subscriber role on all subscriptions.
+externalGlobalSubscribers: []
+  # - <service-account-name>@<project-id>.iam.gserviceaccount.com
 
 # Below specs will be merged into all subscriptions specs.
 # They can be overwritten on each subscription if pleased.
@@ -89,11 +103,15 @@ subscriptions: {}
   # # Each short name must be unique.
   # subscriptionShortName01:
   #   name: my-sub-name-01
-
+  #
   #   # A list of full service accounts ID's to get the subscriber role on this subscription.
-  #   subscribers:
-  #     - <some-other-service-account-name>@<my-project-id>.iam.gserviceaccount.com
-
+  #   subscribers: []
+  #     # - <service-account>
+  #
+  #   # A list of full service accounts ID's to get the subscriber role on this subscription.
+  #   externalSubscribers: []
+  #     # - <service-account-name>@<project-id>.iam.gserviceaccount.com
+  #
   #   # Below spec block supports all values from the documentation.
   #   # https://cloud.google.com/config-connector/docs/reference/resource-docs/pubsub/pubsubsubscription#spec
   #   spec:


### PR DESCRIPTION
- Added `.global.projectID` field to match the chart standard from the other charts.
- Refactored the way service accounts are added to topics and subscripts.
- Added quotes on all labels.
- Optimized annotation logic on objects.

Publishers and subscribers are divided into internal and external. Internal only needs the name of the service account, the ID will be taken from `.global.projectID`. 
External publishers and subscribers needs the whole service account ID.
 
```yaml
globalPublishers:
   - <service-account>

externalGlobalPublishers:
  - <service-account-name>@<project-id>.iam.gserviceaccount.com
```

With this change, you will not have to add your service accounts on each topic and subscription, on each environment file, for your project-internal service accounts.