### PR TITLE
chore: pubsub version bump 2.0.0

### DIFF
--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 2.0.0-rc1
+version: 2.0.0


### PR DESCRIPTION
Updated pubsub from `2.0.0-rc1` to `2.0.0`.