### PR TITLE
fix: added static chart-name label to charts

### DIFF
--- a/charts/big-query/Chart.yaml
+++ b/charts/big-query/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: big-query
 description: A Helm chart for creating Google Cloud Big Query resources.
 type: application
-version: 1.3.0
+version: 1.3.1

--- a/charts/big-query/templates/_helpers.tpl
+++ b/charts/big-query/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "big-query.labels" -}}
 app: {{ .Release.Name }}
-chart-name: {{ .Chart.Name }}
+chart-name: "big-query"
 chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0}}

--- a/charts/iam-service-account/Chart.yaml
+++ b/charts/iam-service-account/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: iam-service-account
 description: A Helm chart for creating Google Cloud IAM service accounts.
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/iam-service-account/templates/_helpers.tpl
+++ b/charts/iam-service-account/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "iam-service-account.labels" -}}
 app: {{ .Release.Name }}
-chart-name: {{ .Chart.Name }}
+chart-name: "iam-service-account"
 chart-version: {{ .Chart.Version | replace "." "-" }}
 {{- with .Values.global.labels }}
 {{- toYaml . | nindent 0 }}

--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/pub-sub/templates/_helpers.tpl
+++ b/charts/pub-sub/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "pubsub.labels" -}}
 app: "{{ .Release.Name }}"
-chart-name: "{{ .Chart.Name }}"
+chart-name: "pub-sub"
 chart-version: "{{ .Chart.Version | replace "." "-" }}"
 {{- range $k, $v := .Values.global.labels }}
 {{ printf "%s: %s" $k ($v | quote) }}

--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 3.0.0
+version: 3.0.1

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "sqlinstance.labels" -}}
 app: {{ .Release.Name }}
-chart-name: {{ .Chart.Name }}
+chart-name: "sqlinstance"
 chart-version: {{ .Chart.Version | replace "." "-" }}
 sqlinstance: {{ .Values.name }}
 {{- range $k, $v := .Values.global.labels }}


### PR DESCRIPTION
All charts have below variables added to all resources so that they are easy to see which versions are in use in a Kubernetes cluster. But if you give your dependency chart an alias the `.Chart.Name` will change.
```
chart-name: {{ .Chart.Name }}
chart-version: {{ .Chart.Version | replace "." "-" }}
```

This PR sets the `chart-name` label to a static value on all charts.