### PR TITLE
pubsub: added blank identifier to var

### DIFF
--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 2.0.1
+version: 2.0.2

--- a/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
+++ b/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
@@ -1,7 +1,7 @@
 ############################################################
 #                PubSub IAM Partial Policy                 #
 ############################################################
-{{- required ".global.projectID is required." .Values.global.projectID }}
+{{- $_ := required ".global.projectID is required." .Values.global.projectID }}
 
 {{- range $topic := .Values.topics  }}
 {{- if or $topic.publishers $topic.isDeadletterTopic $.Values.globalPublishers }}


### PR DESCRIPTION
A missing variable identifier was missing which would produce below code.
```
############################################################
#                PubSub IAM Partial Policy                 #
############################################################<google-project-id>
```