### PR TITLE
fix: pubsub policy issues

### DIFF
--- a/charts/pub-sub/Chart.yaml
+++ b/charts/pub-sub/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: pub-sub
 description: A Helm chart for creating Google Cloud Pub/Sub resources.
 type: application
-version: 2.0.2
+version: 2.0.3

--- a/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
+++ b/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
@@ -54,7 +54,7 @@ spec:
 
 
 {{- range $sub := .Values.subscriptions }}
-{{- if or $sub.subscribers $sub.spec.deadLetterPolicy $.Values.globalSubscribers }}
+{{- if or $sub.spec.deadLetterPolicy $sub.subscribers $sub.externalSubscribers $.Values.globalSubscribers $.Values.externalGlobalSubscribers }}
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:

--- a/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
+++ b/charts/pub-sub/templates/pubsub-iam-partial-policy.yaml
@@ -4,7 +4,7 @@
 {{- $_ := required ".global.projectID is required." .Values.global.projectID }}
 
 {{- range $topic := .Values.topics  }}
-{{- if or $topic.publishers $topic.isDeadletterTopic $.Values.globalPublishers }}
+{{- if or $topic.isDeadletterTopic $topic.publishers $topic.externalPublishers $.Values.globalPublishers $.Values.externalGlobalPublishers }}
 
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
@@ -34,7 +34,7 @@ spec:
           {{- fail (printf ".global.projectNumber is not set or is invalid.") -}}
           {{- end }}
         - member: "serviceAccount:service-{{ $projectNumber }}@gcp-sa-pubsub.iam.gserviceaccount.com"
-        {{- else -}}
+        {{- end -}}
 
         {{/* Below logic merges the internal globalPublishers and the publishers on a topic*/}}
         {{- $publishers := concat  ($topic.publishers | default list) $.Values.globalPublishers | uniq }}
@@ -46,7 +46,6 @@ spec:
         {{- $externalPublishers := concat  ($topic.externalPublishers | default list) $.Values.externalGlobalPublishers | uniq }}
         {{- range $sa := $externalPublishers }}
         - member: "serviceAccount:{{ $sa }}"
-        {{- end }}
         {{- end }}
 
 ---


### PR DESCRIPTION
Fixed af bug where the `externalPublishers`, `externalGlobalPublishers`, `externalSubscribers` and `externalGlobalSubscribers` would not trigger the `pubsub-iam-partial-policy.yaml` template.

`isDeadletterTopic: true` will no longer block for other publisher policies.