### PR TITLE
feat: Adjust max length of topic and subscription name to be 200

### DIFF
--- a/charts/pub-sub/templates/pubsub-subscription.yaml
+++ b/charts/pub-sub/templates/pubsub-subscription.yaml
@@ -4,8 +4,8 @@
 
 {{- range $sub := .Values.subscriptions }}
 
-{{- if gt (len $sub.name) 54 }}
-{{- fail (printf "subscription name [%s, len: %d] too long. must have max length of 54." $sub.name (len $sub.name)) }}
+{{- if gt (len $sub.name) 200 }}
+{{- fail (printf "subscription name [%s, len: %d] too long. must have max length of 200." $sub.name (len $sub.name)) }}
 {{- end }}
 
 apiVersion: pubsub.cnrm.cloud.google.com/v1beta1

--- a/charts/pub-sub/templates/pubsub-topic.yaml
+++ b/charts/pub-sub/templates/pubsub-topic.yaml
@@ -4,8 +4,8 @@
 
 {{- range $topic := .Values.topics  }}
 
-{{- if gt (len $topic.name) 54 }}
-{{- fail (printf "topic name [%s, len: %d] too long. must have max length of 54." $topic.name (len $topic.name)) }}
+{{- if gt (len $topic.name) 200 }}
+{{- fail (printf "topic name [%s, len: %d] too long. must have max length of 200." $topic.name (len $topic.name)) }}
 {{- end }}
 
 apiVersion: pubsub.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
Adjusted max length of topic name and subscription name to 200, after verifying the resources could be created, by manipulating the manifest.