### PR TITLE
fix: SQLInstance not being provisioned in defined projectID

### DIFF
--- a/charts/sqlinstance/templates/sqlinstance.yaml
+++ b/charts/sqlinstance/templates/sqlinstance.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- if not .Values.deletionPolicyRemoveResource }}
     cnrm.cloud.google.com/deletion-policy: abandon
     {{- end }}
+    cnrm.cloud.google.com/project-id: {{ .Values.global.projectID }}
     {{- if .Values.argoSyncWave }}
     argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | quote }}
     {{- end }}


### PR DESCRIPTION
Noticed that the SQL Instance is not being provisioned in the projectID defined in the `global.projectID` value. 

When I was doing the developer workflow exercise, I noticed the SQL Instance being provisioned in another google project (think it was something like `dev-michael` or similar). I could change the project by using the `cnrm.cloud.google.com/project-id` annotation. I wasn't quite sure if it is intended that we manually add the annotation or if it should rather use the `global.projectID` to determine which project to provision the SQL Instance to. 

