### PR TITLE
feat: added support for secret manager access

### DIFF
--- a/charts/iam-service-account/Chart.yaml
+++ b/charts/iam-service-account/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: iam-service-account
 description: A Helm chart for creating Google Cloud IAM service accounts.
 type: application
-version: 2.0.1
+version: 2.1.0-rc1

--- a/charts/iam-service-account/templates/iam-policy-member.yaml
+++ b/charts/iam-service-account/templates/iam-policy-member.yaml
@@ -16,3 +16,37 @@ spec:
   member: "serviceAccount:{{ $gkeProjectID }}.svc.id.goog[{{ .Values.workloadIdentity.kubernetesNamespace }}/{{ .Values.name }}]"
   role: roles/iam.workloadIdentityUser
 {{- end }}
+---
+{{- if .Values.googleSecretManagerAccess }}
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: {{ .Values.name }}-secret-accessor
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
+  labels:
+    {{- include "iam-service-account.labels" . | nindent 4 }}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: {{ .Values.name }}
+  member: serviceAccount:{{ .Values.name }}@{{ .Values.global.projectID | required ".global.projectID is required." }}.iam.gserviceaccount.com
+  role: roles/secretmanager.secretAccessor
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: {{ .Values.name }}-secret-viewer
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.argoSyncWave | default "-5" | quote }}
+  labels:
+    {{- include "iam-service-account.labels" . | nindent 4 }}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: {{ .Values.name }}
+  member: "serviceAccount:{{ .Values.name }}@{{ .Values.global.projectID | required ".global.projectID is required." }}.iam.gserviceaccount.com"
+  role: roles/secretmanager.viewer
+{{- end }}

--- a/charts/iam-service-account/values.yaml
+++ b/charts/iam-service-account/values.yaml
@@ -24,6 +24,9 @@ annotations: {}
 # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/
 argoSyncWave: -5
 
+# Gives the service account access to Google Secret Mananger for the given project.
+googleSecretManagerAccess: false
+
 spec:
   # A text description of the service account. Must be less than or equal to 256 UTF-8 bytes.
   description: "Description of Service Account"


### PR DESCRIPTION
Added support for giving the service account the `roles/secretmanager.secretAccessor` and `roles/secretmanager.viewer` by enabling the `.Values.googleSecretManagerAccess` property.