### PR TITLE
Feat : add db flag randompagecost to sqlinstance

### DIFF
--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 3.0.1
+version: 3.0.2

--- a/charts/sqlinstance/templates/sqlinstance.yaml
+++ b/charts/sqlinstance/templates/sqlinstance.yaml
@@ -60,7 +60,7 @@ spec:
       - name: cloudsql.iam_authentication
         value: "on"
       - name: random_page_cost
-        value: 1.1
+        value: "1.1"
       - name: work_mem
         value: {{ include "sqlinstance.work-mem" $ }}
       {{- range $name, $value := .Values.databaseFlags }}

--- a/charts/sqlinstance/templates/sqlinstance.yaml
+++ b/charts/sqlinstance/templates/sqlinstance.yaml
@@ -59,6 +59,8 @@ spec:
     databaseFlags:
       - name: cloudsql.iam_authentication
         value: "on"
+      - name: random_page_cost
+        value: 1.1
       - name: work_mem
         value: {{ include "sqlinstance.work-mem" $ }}
       {{- range $name, $value := .Values.databaseFlags }}


### PR DESCRIPTION
I have tested this on a sample deployment. 
When upgrading the deployment manually via helm, it starts to upgrade/update the database, and for the db-custom tier chosen for my test, that operation takes less than a minute. 

I have confirmed that the flag is applied, both via kubectl describe and by looking at the Cloud Console. 

And yes, for some reason the integer types property has to be put into a string. Idk why. 