### PR TITLE
feat: 4.1.6 hardening of serviceaccounts list

### DIFF
--- a/charts/sqlinstance/Chart.yaml
+++ b/charts/sqlinstance/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: sqlinstance
 description: A Helm chart for creating Google Cloud SQL Instance.
 type: application
-version: 4.1.5
+version: 4.1.6

--- a/charts/sqlinstance/templates/_helpers.tpl
+++ b/charts/sqlinstance/templates/_helpers.tpl
@@ -1,15 +1,71 @@
 ##########################################################
+#              Service account normalization             #
+##########################################################
+
+{{/*
+Normalize a service account "email" value into a fully-qualified SA email.
+
+Accepted inputs:
+  - local@project
+  - local@project.iam
+  - local@project.iam.gserviceaccount.com
+
+Rejected:
+  - local            (no '@')
+  - local@           (missing project)
+  - @project         (missing local)
+
+Returns:
+  - local@project.iam.gserviceaccount.com
+*/}}
+{{- define "sqlinstance.normalizeServiceAccountEmail" -}}
+{{- $raw := required "serviceAccounts[].email is required" . -}}
+
+{{- if not (contains "@" $raw) -}}
+  {{- fail (printf "serviceAccounts[].email must contain '@' (got %q)" $raw) -}}
+{{- end -}}
+
+{{- $parts := splitList "@" $raw -}}
+{{- if ne (len $parts) 2 -}}
+  {{- fail (printf "serviceAccounts[].email must contain exactly one '@' (got %q)" $raw) -}}
+{{- end -}}
+
+{{- $local := index $parts 0 -}}
+{{- $dom := index $parts 1 -}}
+
+{{- if or (eq $local "") (eq $dom "") -}}
+  {{- fail (printf "serviceAccounts[].email must be of form local@project[.iam[.gserviceaccount.com]] (got %q)" $raw) -}}
+{{- end -}}
+
+{{- /* Strip known suffixes to get the project id */ -}}
+{{- $project := $dom -}}
+{{- $project = regexReplaceAll "\\.iam\\.gserviceaccount\\.com$" $project "" -}}
+{{- $project = regexReplaceAll "\\.iam$" $project "" -}}
+
+{{- if eq $project "" -}}
+  {{- fail (printf "serviceAccounts[].email missing project (got %q)" $raw) -}}
+{{- end -}}
+
+{{- printf "%s@%s.iam.gserviceaccount.com" $local $project -}}
+{{- end -}}
+
+
+##########################################################
 #                   Ensure no dublicate SA's             #
 ##########################################################
 
 {{/*
 Validate that legacy serviceAccountName + serviceAccounts do not contain duplicates.
-Duplicates are detected by canonical service account email:
-- legacy serviceAccountName => <name>@<projectID>.iam.gserviceaccount.com
-- serviceAccounts[].name    => <name>@<projectID>.iam.gserviceaccount.com
-- serviceAccounts[].email   => <email> (verbatim)
 
-Fails with a list of duplicate canonical emails.
+Rules for duplicate detection:
+- legacy serviceAccountName:
+    => <serviceAccountName>@<global.projectID>.iam              (DO NOT normalize legacy input)
+- serviceAccounts[].name:
+    => <name>@<global.projectID>.iam                            (old behavior, for duplicate detection)
+- serviceAccounts[].email:
+    => normalized to <local>@<project>.iam.gserviceaccount.com  (rejects values without '@')
+
+Fails with a list of duplicate strings as tracked above.
 
 Usage:
   {{- include "sqlinstance.validateNoDuplicateServiceAccounts" . -}}
@@ -21,37 +77,41 @@ Usage:
 {{- $seen := dict -}}
 {{- $dups := list -}}
 
-{{- /* legacy */ -}}
+{{- /* legacy: keep behavior; no normalization */ -}}
 {{- if .Values.serviceAccountName -}}
-  {{- $email := printf "%s@%s.iam.gserviceaccount.com" .Values.serviceAccountName $projectID -}}
-  {{- if hasKey $seen $email -}}
-    {{- $dups = append $dups $email -}}
+  {{- $legacyID := printf "%s@%s.iam" .Values.serviceAccountName $projectID -}}
+  {{- if hasKey $seen $legacyID -}}
+    {{- $dups = append $dups $legacyID -}}
   {{- else -}}
-    {{- $_ := set $seen $email true -}}
+    {{- $_ := set $seen $legacyID true -}}
   {{- end -}}
 {{- end -}}
 
 {{- /* list */ -}}
 {{- range $sa := $serviceAccounts -}}
-  {{- $email := "" -}}
+  {{- $id := "" -}}
+
   {{- if and (hasKey $sa "email") $sa.email -}}
-    {{- $email = $sa.email -}}
+    {{- /* Normalize/validate email-shaped input */ -}}
+    {{- $id = include "sqlinstance.normalizeServiceAccountEmail" $sa.email -}}
+  {{- else if and (hasKey $sa "name") $sa.name -}}
+    {{- /* Old behavior: name expands to @project.iam */ -}}
+    {{- $id = printf "%s@%s.iam" $sa.name $projectID -}}
   {{- else -}}
-    {{- $email = printf "%s@%s.iam.gserviceaccount.com" $sa.name $projectID -}}
+    {{- fail "Each item in serviceAccounts must have either non-empty 'email' or non-empty 'name'" -}}
   {{- end -}}
 
-  {{- if hasKey $seen $email -}}
-    {{- $dups = append $dups $email -}}
+  {{- if hasKey $seen $id -}}
+    {{- $dups = append $dups $id -}}
   {{- else -}}
-    {{- $_ := set $seen $email true -}}
+    {{- $_ := set $seen $id true -}}
   {{- end -}}
 {{- end -}}
 
 {{- if gt (len $dups) 0 -}}
-{{- fail (printf "Duplicate service account(s) detected across serviceAccountName/serviceAccounts: %s" (join ", " $dups)) -}}
+  {{- fail (printf "Duplicate service account(s) detected across serviceAccountName/serviceAccounts: %s" (join ", " $dups)) -}}
 {{- end -}}
 {{- end -}}
-
 
 ##########################################################
 #                   Define sqlinstance labels:           #

--- a/charts/sqlinstance/templates/iam-policy-member.yaml
+++ b/charts/sqlinstance/templates/iam-policy-member.yaml
@@ -7,7 +7,7 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: sqluser-{{ default $sa.name $sa.email | replace "@" "-" | replace "." "-" | lower | trunc 63 | trimSuffix "-" }}
+  name: sqluser-{{ (coalesce $sa.name $sa.email) | replace "@" "-" | replace "." "-" | lower | trunc 63 | trimSuffix "-" }}
   {{- if $.Values.argoSyncWave }}
   annotations:
     argocd.argoproj.io/sync-wave: {{ $.Values.argoSyncWave | quote }}
@@ -24,11 +24,13 @@ spec:
     external: "projects/{{ $projectID }}"
   role: organizations/909834982171/roles/cloudsql.serviceaccount.access
   {{- if and (hasKey $sa "email") $sa.email }}
-  member: serviceAccount:{{ $sa.email }}.gserviceaccount.com
-  {{- else }}
+  member: serviceAccount:{{ include "sqlinstance.normalizeServiceAccountEmail" $sa.email }}
+  {{- else if and (hasKey $sa "name") $sa.name }}
   memberFrom:
     serviceAccountRef:
       name: {{ $sa.name }}
+  {{- else }}
+  {{- fail "Each item in serviceAccounts must have either non-empty 'email' or non-empty 'name'" -}}
   {{- end }}
 ---
 {{- end }}
@@ -51,7 +53,7 @@ spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
-    external: "projects/{{ .Values.global.projectID }}"
+    external: "projects/{{ .Values.global.projectID | required "A project ID is required" }}"
   role: organizations/909834982171/roles/cloudsql.serviceaccount.access
   memberFrom:
     serviceAccountRef:

--- a/charts/sqlinstance/templates/sqluser.yaml
+++ b/charts/sqlinstance/templates/sqluser.yaml
@@ -2,7 +2,14 @@
 
 {{- range $sa := (default (list) .Values.serviceAccounts) }}
 {{- $projectID := $.Values.global.projectID | required "A project ID is required" -}}
-{{- $resourceID := (ternary $sa.email (printf "%s@%s.iam.gserviceaccount.com" $sa.name $projectID) (hasKey $sa "email")) -}}
+{{- $resourceID := "" -}}
+{{- if and (hasKey $sa "email") $sa.email -}}
+  {{- $resourceID = include "sqlinstance.normalizeServiceAccountEmail" $sa.email -}}
+{{- else if and (hasKey $sa "name") $sa.name -}}
+  {{- $resourceID = printf "%s@%s.iam" $sa.name $projectID -}}
+{{- else -}}
+  {{- fail "Each item in serviceAccounts must have either non-empty 'email' or non-empty 'name'" -}}
+{{- end -}}
 apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLUser
 metadata:

--- a/charts/sqlinstance/tests/iam-policy-member_test.yaml
+++ b/charts/sqlinstance/tests/iam-policy-member_test.yaml
@@ -7,24 +7,35 @@ tests:
     set:
       global.projectID: my-proj
       serviceAccounts: []
-      serviceAccountName: sqlinstance-sa
+      serviceAccountName: randomname-sa
     asserts:
       - hasDocuments:
           count: 1
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          metadata:
-            name: sqluser-sqlinstance-sa
-          spec:
-            resourceRef:
-              apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-              kind: Project
-              external: "projects/my-proj"
-            role: organizations/909834982171/roles/cloudsql.serviceaccount.access
-            memberFrom:
-              serviceAccountRef:
-                name: sqlinstance-sa
+      - isKind:
+          of: IAMPolicyMember
+      - equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: metadata.name
+          value: sqluser-randomname-sa
+      - equal:
+          path: spec.resourceRef.apiVersion
+          value: resourcemanager.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: spec.resourceRef.kind
+          value: Project
+      - equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - equal:
+          path: spec.memberFrom.serviceAccountRef.name
+          value: randomname-sa
+      - notExists:
+          path: spec.member
 
   - it: serviceAccounts with name renders IAMPolicyMember using memberFrom.serviceAccountRef
     set:
@@ -35,16 +46,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          spec:
-            resourceRef:
-              external: "projects/my-proj"
-            role: organizations/909834982171/roles/cloudsql.serviceaccount.access
-            memberFrom:
-              serviceAccountRef:
-                name: sqlinstance-sa
+      - isKind:
+          of: IAMPolicyMember
+      - equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - equal:
+          path: spec.memberFrom.serviceAccountRef.name
+          value: sqlinstance-sa
+      - notExists:
+          path: spec.member
 
   - it: serviceAccounts with email renders IAMPolicyMember using spec.member (cross-project support)
     set:
@@ -55,14 +72,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          spec:
-            resourceRef:
-              external: "projects/my-proj"
-            role: organizations/909834982171/roles/cloudsql.serviceaccount.access
-            member: serviceAccount:other-sa@other-proj.iam.gserviceaccount.com
+      - isKind:
+          of: IAMPolicyMember
+      - equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - equal:
+          path: spec.member
+          value: serviceAccount:other-sa@other-proj.iam.gserviceaccount.com
+      - notExists:
+          path: spec.memberFrom
 
   - it: serviceAccounts list renders one IAMPolicyMember per entry (name + email mix)
     set:
@@ -74,18 +99,54 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          spec:
-            memberFrom:
-              serviceAccountRef:
-                name: sa-one
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          spec:
-            member: serviceAccount:sa-two@other-proj.iam.gserviceaccount.com
+
+      # doc 0 - name -> memberFrom
+      - documentIndex: 0
+        isKind:
+          of: IAMPolicyMember
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - documentIndex: 0
+        equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - documentIndex: 0
+        equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - documentIndex: 0
+        equal:
+          path: spec.memberFrom.serviceAccountRef.name
+          value: sa-one
+      - documentIndex: 0
+        notExists:
+          path: spec.member
+
+      # doc 1 - email -> spec.member
+      - documentIndex: 1
+        isKind:
+          of: IAMPolicyMember
+      - documentIndex: 1
+        equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - documentIndex: 1
+        equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - documentIndex: 1
+        equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - documentIndex: 1
+        equal:
+          path: spec.member
+          value: serviceAccount:sa-two@other-proj.iam.gserviceaccount.com
+      - documentIndex: 1
+        notExists:
+          path: spec.memberFrom
 
   - it: renders BOTH legacy and serviceAccounts IAMPolicyMembers when both are set
     set:
@@ -98,36 +159,74 @@ tests:
       - hasDocuments:
           count: 3
 
-      # Legacy IAMPolicyMember
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          spec:
-            resourceRef:
-              external: "projects/my-proj"
-            role: organizations/909834982171/roles/cloudsql.serviceaccount.access
-            memberFrom:
-              serviceAccountRef:
-                name: legacy-sa
+      # doc 0 - serviceAccounts[0] name -> memberFrom (range renders before legacy)
+      - documentIndex: 0
+        isKind:
+          of: IAMPolicyMember
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - documentIndex: 0
+        equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - documentIndex: 0
+        equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - documentIndex: 0
+        equal:
+          path: spec.memberFrom.serviceAccountRef.name
+          value: sa-one
+      - documentIndex: 0
+        notExists:
+          path: spec.member
 
-      # List: name -> memberFrom
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          spec:
-            resourceRef:
-              external: "projects/my-proj"
-            role: organizations/909834982171/roles/cloudsql.serviceaccount.access
-            memberFrom:
-              serviceAccountRef:
-                name: sa-one
+      # doc 1 - serviceAccounts[1] email -> spec.member
+      - documentIndex: 1
+        isKind:
+          of: IAMPolicyMember
+      - documentIndex: 1
+        equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - documentIndex: 1
+        equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - documentIndex: 1
+        equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - documentIndex: 1
+        equal:
+          path: spec.member
+          value: serviceAccount:sa-two@other-proj.iam.gserviceaccount.com
+      - documentIndex: 1
+        notExists:
+          path: spec.memberFrom
 
-      # List: email -> spec.member
-      - containsDocument:
-          apiVersion: iam.cnrm.cloud.google.com/v1beta1
-          kind: IAMPolicyMember
-          spec:
-            resourceRef:
-              external: "projects/my-proj"
-            role: organizations/909834982171/roles/cloudsql.serviceaccount.access
-            member: serviceAccount:sa-two@other-proj.iam.gserviceaccount.com
+      # doc 2 - legacy (renders after range)
+      - documentIndex: 2
+        isKind:
+          of: IAMPolicyMember
+      - documentIndex: 2
+        equal:
+          path: apiVersion
+          value: iam.cnrm.cloud.google.com/v1beta1
+      - documentIndex: 2
+        equal:
+          path: spec.resourceRef.external
+          value: "projects/my-proj"
+      - documentIndex: 2
+        equal:
+          path: spec.role
+          value: organizations/909834982171/roles/cloudsql.serviceaccount.access
+      - documentIndex: 2
+        equal:
+          path: spec.memberFrom.serviceAccountRef.name
+          value: legacy-sa
+      - documentIndex: 2
+        notExists:
+          path: spec.member

--- a/charts/sqlinstance/tests/sqluser_test.yaml
+++ b/charts/sqlinstance/tests/sqluser_test.yaml
@@ -3,21 +3,12 @@ templates:
   - ../templates/sqluser.yaml
 
 tests:
-  - it: renders legacy SQLUser by default (values.yaml has serviceAccountName set)
+  - it: renders nothing when nothing is provided (values.yaml in Chart has serviceAccountName set)
     set:
       global.projectID: my-proj
     asserts:
       - hasDocuments:
-          count: 1
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          metadata:
-            name: sqlinstance-sa
-          spec:
-            instanceRef:
-              name: sqlinstance-sample
-            resourceID: sqlinstance-sa@my-proj.iam.gserviceaccount.com
+          count: 0
 
   - it: renders nothing when legacy is disabled and no serviceAccounts are provided
     set:
@@ -27,7 +18,37 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders SQLUsers from serviceAccounts list (same-project names expanded)
+  #####################################################################
+  # serviceAccounts[].name uses old behavior: <name>@<global.projectID>.iam
+  #####################################################################
+  - it: renders SQLUser from serviceAccounts list (name expands to @project.iam)
+    set:
+      global.projectID: my-proj
+      name: my-sql
+      serviceAccounts:
+        - name: sa-one
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: SQLUser
+      - equal:
+          path: apiVersion
+          value: sql.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: metadata.name
+          value: sa-one
+      - equal:
+          path: spec.type
+          value: CLOUD_IAM_SERVICE_ACCOUNT
+      - equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - equal:
+          path: spec.resourceID
+          value: sa-one@my-proj.iam
+
+  - it: renders SQLUsers from serviceAccounts list (two names expand to @project.iam)
     set:
       global.projectID: my-proj
       name: my-sql
@@ -38,26 +59,97 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          metadata:
-            name: sa-one
-          spec:
-            instanceRef:
-              name: my-sql
-            resourceID: sa-one@my-proj.iam.gserviceaccount.com
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          metadata:
-            name: sa-two
-          spec:
-            instanceRef:
-              name: my-sql
-            resourceID: sa-two@my-proj.iam.gserviceaccount.com
 
-  - it: supports cross-project SA via email field (resourceID uses email verbatim)
+      # doc 0
+      - documentIndex: 0
+        isKind:
+          of: SQLUser
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: sql.cnrm.cloud.google.com/v1beta1
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: sa-one
+      - documentIndex: 0
+        equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - documentIndex: 0
+        equal:
+          path: spec.resourceID
+          value: sa-one@my-proj.iam
+
+      # doc 1
+      - documentIndex: 1
+        isKind:
+          of: SQLUser
+      - documentIndex: 1
+        equal:
+          path: apiVersion
+          value: sql.cnrm.cloud.google.com/v1beta1
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: sa-two
+      - documentIndex: 1
+        equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - documentIndex: 1
+        equal:
+          path: spec.resourceID
+          value: sa-two@my-proj.iam
+
+  #####################################################################
+  # serviceAccounts[].email is normalized to full SA email
+  #####################################################################
+  - it: "normalizes serviceAccounts email: local@proj -> local@proj.iam.gserviceaccount.com"
+    set:
+      global.projectID: my-proj
+      name: my-sql
+      serviceAccountName: ""
+      serviceAccounts:
+        - email: other-sa@other-proj
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: SQLUser
+      - equal:
+          path: apiVersion
+          value: sql.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - equal:
+          path: spec.resourceID
+          value: other-sa@other-proj.iam.gserviceaccount.com
+
+  - it: "normalizes serviceAccounts email: local@proj.iam -> local@proj.iam.gserviceaccount.com"
+    set:
+      global.projectID: my-proj
+      name: my-sql
+      serviceAccountName: ""
+      serviceAccounts:
+        - email: other-sa@other-proj.iam
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: SQLUser
+      - equal:
+          path: apiVersion
+          value: sql.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - equal:
+          path: spec.resourceID
+          value: other-sa@other-proj.iam.gserviceaccount.com
+
+  - it: keeps serviceAccounts email fully qualified as-is (already canonical)
     set:
       global.projectID: my-proj
       name: my-sql
@@ -67,14 +159,35 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          spec:
-            instanceRef:
-              name: my-sql
-            resourceID: other-sa@other-proj.iam.gserviceaccount.com
+      - isKind:
+          of: SQLUser
+      - equal:
+          path: apiVersion
+          value: sql.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - equal:
+          path: spec.resourceID
+          value: other-sa@other-proj.iam.gserviceaccount.com
 
+  #####################################################################
+  # invalid email input should fail (no '@')
+  #####################################################################
+  - it: fails when serviceAccounts email does not contain '@'
+    set:
+      global.projectID: my-proj
+      name: my-sql
+      serviceAccountName: ""
+      serviceAccounts:
+        - email: other-sa
+    asserts:
+      - failedTemplate:
+          errorMessage: serviceAccounts[].email must contain '@' (got "other-sa")
+
+  #####################################################################
+  # Legacy behavior unchanged (resourceID ends with .iam)
+  #####################################################################
   - it: renders legacy when serviceAccounts is explicitly empty and serviceAccountName is set
     set:
       global.projectID: my-proj
@@ -84,15 +197,20 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          metadata:
-            name: legacy-sa
-          spec:
-            instanceRef:
-              name: my-sql
-            resourceID: legacy-sa@my-proj.iam.gserviceaccount.com
+      - isKind:
+          of: SQLUser
+      - equal:
+          path: apiVersion
+          value: sql.cnrm.cloud.google.com/v1beta1
+      - equal:
+          path: metadata.name
+          value: legacy-sa
+      - equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - equal:
+          path: spec.resourceID
+          value: legacy-sa@my-proj.iam
 
   - it: renders nothing when serviceAccounts is explicitly empty and legacy is disabled
     set:
@@ -103,43 +221,95 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: renders BOTH legacy SQLUser and serviceAccounts SQLUsers when both are set
+
+  #####################################################################
+  # Duplicate detection (based on helper logic)
+  #####################################################################
+  - it: fails when legacy and serviceAccounts.name refer to same canonical email
+    set:
+      global.projectID: my-proj
+      name: my-sql
+      serviceAccountName: dup-sa
+      serviceAccounts:
+        - name: dup-sa
+    asserts:
+      - failedTemplate:
+          errorMessage: "Duplicate service account(s) detected across serviceAccountName/serviceAccounts: dup-sa@my-proj.iam"
+
+  - it: fails when two serviceAccounts.email forms normalize to the same canonical email
+    set:
+      global.projectID: my-proj
+      name: my-sql
+      serviceAccountName: ""
+      serviceAccounts:
+        - email: other-sa@other-proj
+        - email: other-sa@other-proj.iam.gserviceaccount.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "Duplicate service account(s) detected across serviceAccountName/serviceAccounts: other-sa@other-proj.iam.gserviceaccount.com"
+
+  #####################################################################
+  # Both legacy + list renders (non-duplicate)
+  #####################################################################
+  - it: renders BOTH legacy SQLUser and serviceAccounts SQLUsers when both are set (non-duplicate)
     set:
       global.projectID: my-proj
       name: my-sql
       serviceAccountName: legacy-sa
       serviceAccounts:
         - name: sa-one
-        - email: sa-two@other-proj.iam.gserviceaccount.com
+        - email: sa-two@other-proj
     asserts:
       - hasDocuments:
           count: 3
 
-      # Legacy SQLUser (same-project expansion)
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          metadata:
-            name: legacy-sa
-          spec:
-            instanceRef:
-              name: my-sql
-            resourceID: legacy-sa@my-proj.iam.gserviceaccount.com
+      # doc 0 - list name (range renders first)
+      - documentIndex: 0
+        isKind:
+          of: SQLUser
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: sa-one
+      - documentIndex: 0
+        equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - documentIndex: 0
+        equal:
+          path: spec.resourceID
+          value: sa-one@my-proj.iam
 
-      # List: name -> expanded to same-project email
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          spec:
-            instanceRef:
-              name: my-sql
-            resourceID: sa-one@my-proj.iam.gserviceaccount.com
+      # doc 1 - list email normalized (metadata.name is derived from email)
+      - documentIndex: 1
+        isKind:
+          of: SQLUser
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: sa-two-other-proj
+      - documentIndex: 1
+        equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - documentIndex: 1
+        equal:
+          path: spec.resourceID
+          value: sa-two@other-proj.iam.gserviceaccount.com
 
-      # List: email -> verbatim
-      - containsDocument:
-          apiVersion: sql.cnrm.cloud.google.com/v1beta1
-          kind: SQLUser
-          spec:
-            instanceRef:
-              name: my-sql
-            resourceID: sa-two@other-proj.iam.gserviceaccount.com
+      # doc 2 - legacy (renders after range)
+      - documentIndex: 2
+        isKind:
+          of: SQLUser
+      - documentIndex: 2
+        equal:
+          path: metadata.name
+          value: legacy-sa
+      - documentIndex: 2
+        equal:
+          path: spec.instanceRef.name
+          value: my-sql
+      - documentIndex: 2
+        equal:
+          path: spec.resourceID
+          value: legacy-sa@my-proj.iam


### PR DESCRIPTION
The previous version introduced that when supplying a "local" IAM SA via serviceaccounts.name, then the resourceID was getting ".gserviceaccount.com" suffixed to it. 

This is an immutable property, resulting in a need for deleting/resyncing when ITU bumps. 
This is not viable. 

When the IAM SA is from within the same GCP proj as the sqlinstance, the resourceId does not need the ".gserviceaccount" suffix. 

While enforcing this, I have also tried hardening the serviceaccounts.email input, so that it handles more cases, so that errors wont occur when eg. a Developer has written an email without "gserviceaccount.com" or ".iam". 